### PR TITLE
fix(transport): drop TTL-expired messages at read_outbox (TICKET-007 prereq)

### DIFF
--- a/steward/federation_transport.py
+++ b/steward/federation_transport.py
@@ -270,6 +270,15 @@ class NadiFederationTransport:
                         stage="transport_parse",
                     )
                     continue
+                # TTL gate: silently drop expired messages so the gateway doesn't
+                # waste cycles signing-checking 22-day-old hub backlog. No
+                # quarantine — staleness is not malice, just delivery lag.
+                ttl = item.get("ttl_s")
+                ts = item.get("timestamp")
+                if isinstance(ttl, (int, float)) and ttl > 0 and isinstance(ts, (int, float)):
+                    if time.time() > ts + ttl:
+                        self._seen.add(fingerprint)
+                        continue
                 expected_hash = str(item.get("payload_hash", "")).strip()
                 if expected_hash:
                     actual_hash = self._payload_hash(item.get("payload", {}))

--- a/tests/test_federation_transport.py
+++ b/tests/test_federation_transport.py
@@ -9,6 +9,7 @@ Validates:
 
 import hashlib
 import json
+import time
 
 from steward.federation_crypto import verify_payload_signature
 from steward.federation_transport import (
@@ -120,6 +121,33 @@ class TestNadiFederationTransport:
     def test_read_outbox_empty(self, tmp_path):
         transport = NadiFederationTransport(str(tmp_path))
         assert transport.read_outbox() == []
+
+    def test_read_outbox_silently_drops_ttl_expired_messages(self, tmp_path):
+        """Stale messages (timestamp + ttl_s < now) are dropped without
+        quarantine — staleness is delivery lag, not malice. Prevents the
+        gateway from wasting cycles on hub-buffer backlog."""
+        transport = NadiFederationTransport(str(tmp_path))
+        fresh = {
+            "source": "ag_fresh", "target": "steward", "operation": "heartbeat",
+            "payload": {}, "timestamp": time.time(), "ttl_s": 900.0,
+        }
+        stale = {
+            "source": "ag_stale", "target": "steward", "operation": "heartbeat",
+            "payload": {}, "timestamp": time.time() - 7200, "ttl_s": 900.0,
+        }
+        (tmp_path / "nadi_inbox.json").write_text(json.dumps([fresh, stale]))
+
+        msgs = transport.read_outbox()
+
+        sources = {m["source"] for m in msgs}
+        assert "ag_fresh" in sources
+        assert "ag_stale" not in sources
+        # No quarantine for stale (it's not an integrity violation)
+        quarantine_files = [
+            p for p in (tmp_path / "quarantine").glob("*.json")
+            if p.name != "index.json"
+        ] if (tmp_path / "quarantine").exists() else []
+        assert len(quarantine_files) == 0
 
     def test_append_to_inbox_writes_outbox(self, tmp_path):
         """append_to_inbox writes OUR outbox (nadi_outbox.json)."""


### PR DESCRIPTION
## Summary

Prerequisite to TICKET-007 Phase 3 (Great Registry Purge). Adds a TTL
gate to `NadiFederationTransport.read_outbox` so 22-day-old hub-backlog
messages don't keep flooding the gateway logs every cycle.

## Why

After heartbeat-bleeding fix (steward-federation#2 + steward#54),
diagnostics showed 144 stale unsigned heartbeats from steward-federation
sitting at the BUFFER_CAP=144 in the hub repo (timestamps 22 days old,
ttl_s=900). Steward read them on every cycle, ran signature checks,
quarantined them as `unknown_sender`, repeat.

Without this filter: Phase 3 truncates verified_agents.json and lets
nodes self-re-register, but the stale-source backlog still floods
gateway logs and CPU until BUFFER_CAP rotates them out — could take
many cycles.

## Change

One block in `read_outbox`, after the source/operation validation:

```python
ttl = item.get("ttl_s")
ts = item.get("timestamp")
if isinstance(ttl, (int, float)) and ttl > 0 and isinstance(ts, (int, float)):
    if time.time() > ts + ttl:
        self._seen.add(fingerprint)
        continue
```

Silent drop (added to `_seen` to avoid re-eval). No quarantine —
staleness is delivery lag, not malice.

## Test plan

- [x] `test_read_outbox_silently_drops_ttl_expired_messages` — fresh
      passes through, stale dropped, zero quarantine files
- [x] All 22 transport tests green
- [x] All 205 federation tests green
- [ ] Post-merge: next steward cycle shows 72 stale `steward-federation`
      `unknown_sender` blocks gone from gateway logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)