### PR TITLE
fix(federation): transport bypass + env-aware keystore + cache v3 (TICKET-009 P2)

### DIFF
--- a/.github/workflows/steward-heartbeat.yml
+++ b/.github/workflows/steward-heartbeat.yml
@@ -55,9 +55,9 @@ jobs:
             data/federation/
           # v2 generation — invalidates pre-TICKET-008 caches that contained the
           # ghost ag_e3331b8d3b0d20a7 entry. See issue forensics for context.
-          key: steward-state-v2-main
+          key: steward-state-v3-main
           restore-keys: |
-            steward-state-v2-
+            steward-state-v3-
 
       - name: Run autonomous cycle
         env:
@@ -118,4 +118,4 @@ jobs:
           path: |
             .steward/
             data/federation/
-          key: steward-state-v2-main
+          key: steward-state-v3-main

--- a/data/federation/verified_agents.archived.20260427_081737Z.json
+++ b/data/federation/verified_agents.archived.20260427_081737Z.json
@@ -1,0 +1,15 @@
+{
+  "ag_e3331b8d3b0d20a7": {
+    "agent_name": "ag_e3331b8d3b0d20a7",
+    "capabilities": [
+      "autonomous_daemon",
+      "ci_automation",
+      "code_analysis",
+      "federation_bridge",
+      "task_execution"
+    ],
+    "node_id": "ag_e3331b8d3b0d20a7",
+    "public_key": "d7003dffc7ec2bf969f3e1e7d33f47b56e21136fd9962e2ba3e1292e2cc3d9c5",
+    "updated_at": 1777261150.4487493
+  }
+}

--- a/data/federation/verified_agents.json
+++ b/data/federation/verified_agents.json
@@ -1,15 +1,1 @@
-{
-  "ag_e3331b8d3b0d20a7": {
-    "agent_name": "ag_e3331b8d3b0d20a7",
-    "capabilities": [
-      "autonomous_daemon",
-      "ci_automation",
-      "code_analysis",
-      "federation_bridge",
-      "task_execution"
-    ],
-    "node_id": "ag_e3331b8d3b0d20a7",
-    "public_key": "d7003dffc7ec2bf969f3e1e7d33f47b56e21136fd9962e2ba3e1292e2cc3d9c5",
-    "updated_at": 1777261150.4487493
-  }
-}
+{}

--- a/steward/federation_crypto.py
+++ b/steward/federation_crypto.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import logging
+import os
 from pathlib import Path
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+
+logger = logging.getLogger("STEWARD.FEDERATION_CRYPTO")
 
 
 def derive_node_id(public_key_hex: str, length: int = 16) -> str:
@@ -14,7 +18,51 @@ def derive_node_id(public_key_hex: str, length: int = 16) -> str:
     return f"ag_{digest[:length]}"
 
 
+def _load_from_hex_or_json(text: str) -> tuple[str, str, str] | None:
+    """Try parsing `text` as JSON-blob or raw 32-byte hex. Returns
+    (priv_hex, pub_hex, node_id) or None on failure."""
+    text = (text or "").strip()
+    if not text:
+        return None
+    # JSON blob
+    try:
+        blob = json.loads(text)
+        if isinstance(blob, dict):
+            priv = str(blob.get("private_key", "")).strip()
+            pub = str(blob.get("public_key", "")).strip()
+            if priv and pub:
+                node_id = str(blob.get("node_id") or "").strip() or derive_node_id(pub)
+                return priv, pub, node_id
+    except (json.JSONDecodeError, ValueError):
+        pass
+    # Raw hex (32 bytes)
+    try:
+        raw = bytes.fromhex(text)
+        if len(raw) == 32:
+            sk = Ed25519PrivateKey.from_private_bytes(raw)
+            pub = sk.public_key().public_bytes(
+                serialization.Encoding.Raw, serialization.PublicFormat.Raw,
+            ).hex()
+            return raw.hex(), pub, derive_node_id(pub)
+    except (ValueError, TypeError):
+        pass
+    return None
+
+
 class NodeKeyStore:
+    """Persistent Ed25519 key holder.
+
+    Resolution order (highest priority first):
+      1. NODE_PRIVATE_KEY environment variable (raw 32-byte hex OR JSON blob)
+      2. The file at `path` (legacy fallback)
+      3. Generate fresh ephemeral keypair (last resort, logs WARNING)
+
+    The env-first policy means a node's identity is governed by the
+    GitHub-Actions secret (Genesis-Hook target), and rotating the secret
+    rotates the identity — without leaving a stale key on disk that
+    could be re-leaked by a misconfigured workflow.
+    """
+
     def __init__(self, path: str | Path) -> None:
         self._path = Path(path)
         self.private_key = ""
@@ -22,22 +70,40 @@ class NodeKeyStore:
         self.node_id = ""
 
     def ensure_keys(self) -> None:
+        # 1. Env wins
+        env_text = os.environ.get("NODE_PRIVATE_KEY", "")
+        loaded = _load_from_hex_or_json(env_text) if env_text else None
+        if loaded:
+            self.private_key, self.public_key, self.node_id = loaded
+            logger.info(
+                "nodekeystore: loaded identity from NODE_PRIVATE_KEY env (node_id=%s)",
+                self.node_id,
+            )
+            return
+        # 2. File fallback
         if self._path.exists():
             self._load()
             if self.private_key and self.public_key:
+                logger.info(
+                    "nodekeystore: loaded from file %s (env unset) — node_id=%s",
+                    self._path, self.node_id,
+                )
                 return
+        # 3. Last resort
+        logger.warning(
+            "nodekeystore: env unset and %s missing/invalid — generating ephemeral keypair",
+            self._path,
+        )
         self._generate()
 
     def _load(self) -> None:
         try:
-            payload = json.loads(self._path.read_text())
-        except (json.JSONDecodeError, OSError):
-            payload = {}
-        self.private_key = str(payload.get("private_key", "")).strip()
-        self.public_key = str(payload.get("public_key", "")).strip()
-        self.node_id = str(payload.get("node_id", "")).strip()
-        if self.public_key and not self.node_id:
-            self.node_id = derive_node_id(self.public_key)
+            text = self._path.read_text()
+        except OSError:
+            return
+        loaded = _load_from_hex_or_json(text)
+        if loaded:
+            self.private_key, self.public_key, self.node_id = loaded
 
     def _generate(self) -> None:
         private_key = Ed25519PrivateKey.generate()

--- a/steward/federation_transport.py
+++ b/steward/federation_transport.py
@@ -86,7 +86,27 @@ class NadiFederationTransport:
         return hashlib.sha256(encoded.encode()).hexdigest()
 
     def _with_integrity_fields(self, payload: dict) -> dict:
+        """Attach integrity fields (legacy path) UNLESS the message is
+        already signed by an upstream layer.
+
+        FederationBridge.flush_outbound (TICKET-007 #54) signs every
+        outbound message with the canonical wire format
+        (source = derive_node_id(public_key), payload_hash over the whole
+        message minus sig fields, base64 ed25519 signature). If those
+        three fields are populated, this transport must NOT overwrite
+        them — doing so produced ghost-identity emissions for cycles.
+
+        The legacy file-based-key path is preserved only for messages
+        that arrive without signing (back-compat for any code that
+        still constructs raw FederationMessage dicts and hands them to
+        the transport directly).
+        """
         enriched = dict(payload)
+        if enriched.get("source") and enriched.get("payload_hash") and enriched.get("signature"):
+            # Pre-signed by FederationBridge — only stamp a message_id if missing.
+            enriched.setdefault("message_id", str(uuid.uuid4()))
+            return enriched
+        # Legacy path: payload-scoped hash, transport signs with file-based key
         enriched["source"] = self.node_id
         enriched["message_id"] = str(uuid.uuid4())
         enriched["payload_hash"] = self._payload_hash(enriched.get("payload", {}))


### PR DESCRIPTION
Closes ghost-emitter loop. Transport no longer clobbers pre-signed messages, NodeKeyStore reads NODE_PRIVATE_KEY env first, cache v3, registry purged. 145/145 critical tests green.