### PR TITLE
fix(federation): reject expired heartbeats on receipt (phantom heartbeat)

### DIFF
--- a/docs/DEV_WORKFLOW.md
+++ b/docs/DEV_WORKFLOW.md
@@ -1,0 +1,19 @@
+# Development Workflow — Steward
+
+## Why this exists
+The Steward lives in its own repo: a heartbeat mechanism periodically commits
+`.steward/` state and rebases against `main`. Working on features directly inside
+the runtime clone therefore causes HEAD/refs to move under you, and agent-reported
+commits/pushes may be silently lost. This document is the hard-won rule set.
+
+## Rules
+1. **Never do feature work in the runtime clone** (`/Users/ss/projects/steward`).
+   Use a separate real `git clone` (own `.git`, true quarantine — not a worktree,
+   which shares `.git`).
+2. **Verify the baseline before writing code**, per `ci.yml`:
+   `pip install steward-protocol[providers]` → `pip install -e ".[providers,search,api,dev]"`
+   → `pytest`. Know which tests are already red on `main` before you start.
+3. **Always double-verify state changes independently.** After `git commit`, run
+   `git log --oneline -1`. After `git push`, run `git ls-remote origin | grep <branch>`.
+   Never trust an agent's success message for commit/push.
+4. **Deliver via Pull Request**, never direct-push to `main`.

--- a/steward/hooks/dharma.py
+++ b/steward/hooks/dharma.py
@@ -27,6 +27,11 @@ from vibe_core.di import ServiceRegistry
 logger = logging.getLogger("STEWARD.HOOKS.DHARMA")
 
 
+# Default TTL for inbox messages lacking explicit ttl_s (2h): generous enough
+# for legitimate fresh heartbeats, rejects day/month-old phantoms (Befund §47c).
+DEFAULT_NADI_TTL_S = 7200.0
+
+
 class DharmaHealthHook(BasePhaseHook):
     """Monitor vedana health — set anomaly flag when critical."""
 
@@ -355,68 +360,7 @@ class DharmaFederationHook(BasePhaseHook):
                 reaper = ServiceRegistry.get(SVC_REAPER)
                 federation = ServiceRegistry.get(SVC_FEDERATION)
                 if reaper is not None and federation is not None:
-                    recorded = set()
-                    # Process agent_claim messages first (cryptographic identity)
-                    for msg in messages:
-                        if msg.get("operation") == "federation.agent_claim":
-                            federation.ingest("federation.agent_claim", msg.get("payload", msg))
-                    # Then record heartbeats
-                    for msg in messages:
-                        # Prefer agent_id (human-readable identity) over source (node crypto ID)
-                        peer_id = msg.get("agent_id") or msg.get("source")
-                        if not peer_id:
-                            continue
-                        # Crypto IDs (ag_xxxxx) are node signatures, not identities.
-                        # Skip unless already a known peer (prevents false identity injection).
-                        if peer_id.startswith("ag_") and peer_id not in reaper._peers:
-                            continue
-                        # SIGNATURE VALIDATION (Path 1 — nadi_inbox relay)
-                        signature = str(msg.get("signature", "")).strip()
-                        payload_hash = str(msg.get("payload_hash", "")).strip()
-                        if signature and payload_hash:
-                            # Message is signed — validate Ed25519
-                            source_node = msg.get("source", peer_id)
-                            verified = False
-                            if federation is not None and hasattr(federation, "get_verified_agent"):
-                                record = federation.get_verified_agent(source_node)
-                                if isinstance(record, dict):
-                                    pub_key = str(record.get("public_key", "")).strip()
-                                    if pub_key:
-                                        try:
-                                            from steward.federation_crypto import verify_payload_signature
-
-                                            verified = verify_payload_signature(pub_key, payload_hash, signature)
-                                        except Exception:
-                                            verified = False
-                                    if not verified:
-                                        logger.warning(
-                                            "FEDERATION: REJECTED signed heartbeat from %s — invalid Ed25519 signature",
-                                            peer_id,
-                                        )
-                                        continue
-                                else:
-                                    # Signed but unknown sender — reject
-                                    logger.warning(
-                                        "FEDERATION: REJECTED signed heartbeat from unknown sender %s — no public key on record",
-                                        peer_id,
-                                    )
-                                    continue
-                        else:
-                            # Unsigned message — tolerate only known peers (Path 3 agents)
-                            if peer_id not in reaper._peers:
-                                logger.debug(
-                                    "FEDERATION: SKIPPED unsigned heartbeat from unknown %s — no crypto proof",
-                                    peer_id,
-                                )
-                                continue
-                        reaper.record_heartbeat(agent_id=peer_id, source="nadi_inbox")
-                        recorded.add(peer_id)
-                    if recorded:
-                        logger.info(
-                            "FEDERATION: recorded heartbeats for %d inbox sources: %s",
-                            len(recorded),
-                            ", ".join(sorted(recorded)),
-                        )
+                    self._process_inbox_messages(messages, reaper, federation)
             except (json.JSONDecodeError, OSError) as e:
                 # Was silently swallowed — a corrupt/unreadable inbox made the whole
                 # federation look silent with no trace. Behaviour unchanged (skip this
@@ -477,3 +421,92 @@ class DharmaFederationHook(BasePhaseHook):
                     logger.info("FEDERATION: gateway processed %d inbound messages", processed)
             else:
                 federation.process_inbound(transport)
+
+    def _process_inbox_messages(self, messages: list, reaper, federation) -> None:
+        """Process inbox: agent_claim + heartbeats, with TTL validation.
+
+        Rejects expired messages (age > ttl_s, default DEFAULT_NADI_TTL_S) so that
+        stale replayed heartbeats cannot keep dead peers artificially alive
+        (phantom heartbeat, Befund §44-47). Missing timestamp = fail-closed skip.
+        """
+        recorded = set()
+        # Process agent_claim messages first (cryptographic identity)
+        for msg in messages:
+            if msg.get("operation") == "federation.agent_claim":
+                federation.ingest("federation.agent_claim", msg.get("payload", msg))
+        # Then record heartbeats
+        for msg in messages:
+            # Prefer agent_id (human-readable identity) over source (node crypto ID)
+            peer_id = msg.get("agent_id") or msg.get("source")
+            if not peer_id:
+                continue
+            # Crypto IDs (ag_xxxxx) are node signatures, not identities.
+            # Skip unless already a known peer (prevents false identity injection).
+            if peer_id.startswith("ag_") and peer_id not in reaper._peers:
+                continue
+            # SIGNATURE VALIDATION (Path 1 — nadi_inbox relay)
+            signature = str(msg.get("signature", "")).strip()
+            payload_hash = str(msg.get("payload_hash", "")).strip()
+            if signature and payload_hash:
+                # Message is signed — validate Ed25519
+                source_node = msg.get("source", peer_id)
+                verified = False
+                if federation is not None and hasattr(federation, "get_verified_agent"):
+                    record = federation.get_verified_agent(source_node)
+                    if isinstance(record, dict):
+                        pub_key = str(record.get("public_key", "")).strip()
+                        if pub_key:
+                            try:
+                                from steward.federation_crypto import verify_payload_signature
+
+                                verified = verify_payload_signature(pub_key, payload_hash, signature)
+                            except Exception:
+                                verified = False
+                        if not verified:
+                            logger.warning(
+                                "FEDERATION: REJECTED signed heartbeat from %s — invalid Ed25519 signature",
+                                peer_id,
+                            )
+                            continue
+                    else:
+                        # Signed but unknown sender — reject
+                        logger.warning(
+                            "FEDERATION: REJECTED signed heartbeat from unknown sender %s — no public key on record",
+                            peer_id,
+                        )
+                        continue
+            else:
+                # Unsigned message — tolerate only known peers (Path 3 agents)
+                if peer_id not in reaper._peers:
+                    logger.debug(
+                        "FEDERATION: SKIPPED unsigned heartbeat from unknown %s — no crypto proof",
+                        peer_id,
+                    )
+                    continue
+
+            # TTL VALIDATION — reject expired messages (phantom heartbeat fix, Befund §47).
+            # Age is derived from timestamp; missing timestamp fails closed (no age = no trust).
+            timestamp = msg.get("timestamp")
+            if timestamp is None:
+                logger.debug(
+                    "FEDERATION: SKIPPED heartbeat from %s — no timestamp (fail-closed)",
+                    peer_id,
+                )
+                continue
+            ttl_s = msg.get("ttl_s", DEFAULT_NADI_TTL_S)
+            age_s = time.time() - timestamp
+            if age_s > ttl_s:
+                logger.debug(
+                    "FEDERATION: SKIPPED expired heartbeat from %s (age %.0fs > TTL %.0fs)",
+                    peer_id,
+                    age_s,
+                    ttl_s,
+                )
+                continue
+
+            reaper.record_heartbeat(agent_id=peer_id, source="nadi_inbox")
+            recorded.add(peer_id)
+        if recorded:
+            logger.info(
+                "FEDERATION: recorded heartbeats for %d inbox sources: %s", len(recorded), ", ".join(sorted(recorded))
+            )

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -1559,3 +1559,115 @@ class TestAgentClaimRegistersPeerInReaper:
         assert "agent-city" in alive_names
         # must NOT be keyed by the crypto hash
         assert reaper.get_peer(node_id) is None
+
+
+class TestFederationInboxTTLFilter:
+    """TTL validation in _process_inbox_messages — the REAL method, effect-based."""
+
+    def _known(self, HeartbeatReaper, peer_id, offset=500.0):
+        import time
+
+        r = HeartbeatReaper()
+        r.record_heartbeat(agent_id=peer_id, source="setup")
+        r.get_peer(peer_id).last_seen = time.time() - offset
+        return r, r.get_peer(peer_id).last_seen
+
+    def test_expired_heartbeat_not_recorded(self):
+        import time
+
+        from steward.hooks.dharma import DharmaFederationHook
+        from steward.reaper import HeartbeatReaper
+
+        r, base = self._known(HeartbeatReaper, "phantom-old")
+        msg = {
+            "operation": "heartbeat",
+            "agent_id": "phantom-old",
+            "source": "phantom-old",
+            "timestamp": time.time() - 14400.0,
+            "ttl_s": 7200.0,
+        }
+        DharmaFederationHook()._process_inbox_messages([msg], r, None)
+        assert r.get_peer("phantom-old").last_seen == base
+
+    def test_fresh_heartbeat_recorded(self):
+        import time
+
+        from steward.hooks.dharma import DharmaFederationHook
+        from steward.reaper import HeartbeatReaper
+
+        r, base = self._known(HeartbeatReaper, "peer-fresh")
+        msg = {
+            "operation": "heartbeat",
+            "agent_id": "peer-fresh",
+            "source": "peer-fresh",
+            "timestamp": time.time() - 60.0,
+            "ttl_s": 7200.0,
+        }
+        DharmaFederationHook()._process_inbox_messages([msg], r, None)
+        assert r.get_peer("peer-fresh").last_seen > base
+
+    def test_missing_ttl_default_accepts_fresh(self):
+        import time
+
+        from steward.hooks.dharma import DharmaFederationHook
+        from steward.reaper import HeartbeatReaper
+
+        r, base = self._known(HeartbeatReaper, "peer-default")
+        msg = {
+            "operation": "heartbeat",
+            "agent_id": "peer-default",
+            "source": "peer-default",
+            "timestamp": time.time() - 3600.0,
+        }
+        DharmaFederationHook()._process_inbox_messages([msg], r, None)
+        assert r.get_peer("peer-default").last_seen > base
+
+    def test_missing_ttl_default_rejects_old(self):
+        import time
+
+        from steward.hooks.dharma import DharmaFederationHook
+        from steward.reaper import HeartbeatReaper
+
+        r, base = self._known(HeartbeatReaper, "phantom-default")
+        msg = {
+            "operation": "heartbeat",
+            "agent_id": "phantom-default",
+            "source": "phantom-default",
+            "timestamp": time.time() - 10000.0,
+        }
+        DharmaFederationHook()._process_inbox_messages([msg], r, None)
+        assert r.get_peer("phantom-default").last_seen == base
+
+    def test_missing_timestamp_skipped_failclosed(self):
+        from steward.hooks.dharma import DharmaFederationHook
+        from steward.reaper import HeartbeatReaper
+
+        r, base = self._known(HeartbeatReaper, "phantom-no-ts")
+        msg = {"operation": "heartbeat", "agent_id": "phantom-no-ts", "source": "phantom-no-ts", "ttl_s": 7200.0}
+        DharmaFederationHook()._process_inbox_messages([msg], r, None)
+        assert r.get_peer("phantom-no-ts").last_seen == base
+
+    def test_agent_claim_unaffected_by_ttl(self):
+        import time
+
+        from steward.hooks.dharma import DharmaFederationHook
+        from steward.reaper import HeartbeatReaper
+
+        class _Fed:
+            def __init__(self):
+                self.ingested = []
+
+            def ingest(self, op, payload):
+                self.ingested.append((op, payload))
+
+            def get_verified_agent(self, n):
+                return None
+
+        fed = _Fed()
+        claim = {
+            "operation": "federation.agent_claim",
+            "payload": {"agent_id": "claimant"},
+            "timestamp": time.time() - 99999.0,
+        }
+        DharmaFederationHook()._process_inbox_messages([claim], HeartbeatReaper(), fed)
+        assert fed.ingested == [("federation.agent_claim", {"agent_id": "claimant"})]


### PR DESCRIPTION
## Problem
The Steward recorded every signed inbox message as a fresh heartbeat without checking message age. Months-old messages replayed by the hub kept dead nodes marked ALIVE, blocking the healing chain (Healer only acts on suspect/dead peers).

## Fix
Zero-trust receiver: validate TTL after signature, before `record_heartbeat`. Age is derived from `timestamp` (default `DEFAULT_NADI_TTL_S=7200s` when `ttl_s` absent); missing timestamp fails closed. The `agent_claim` path is untouched. Inbox processing extracted into `_process_inbox_messages()` for honest, effect-based testing.

Complements the existing outbound `fix/transport-expired-filter` (TTL drop at read_outbox) — two axes of the same zero-trust principle.

## Tests
Six effect-based tests (real `HeartbeatReaper`, no mocks) assert `last_seen` is NOT refreshed for expired messages. **Mutation-proven**: disabling the TTL check turns the expired tests red. Full test_federation + test_reaper green except one pre-existing unrelated failure (`test_dead_to_evicted_on_third_miss`, a float-comparison bug on main).

Adds `docs/DEV_WORKFLOW.md`.