### PR TITLE
fix(autonomy): HEAL_REPO targets its exact peer, not a blind degraded sweep

### DIFF
--- a/steward/autonomy.py
+++ b/steward/autonomy.py
@@ -419,6 +419,26 @@ class AutonomyEngine:
 
         return result
 
+    @staticmethod
+    def _extract_target_peer(task_title: str) -> str | None:
+        """Extract target peer_id from a HEAL_REPO task title.
+
+        Title format (persistence-safe, mirrors parse_intent_from_title):
+            "[HEAL_REPO] Peer {peer_id} — Kirtan escalation"
+        Peer ids may contain hyphens (agent-city, steward-test), so we anchor
+        on the unambiguous delimiters "Peer " and " — " rather than splitting.
+        Returns the peer_id, or None if the title does not match.
+        """
+        marker = "] Peer "
+        start = task_title.find(marker)
+        if start < 0:
+            return None
+        start += len(marker)
+        end = task_title.find(" — ", start)
+        peer_id = task_title[start:end] if end > start else task_title[start:]
+        peer_id = peer_id.strip()
+        return peer_id or None
+
     async def _execute_heal_repo(self, task: object, task_mgr: object, TaskStatus: object) -> str | None:
         """Execute HEAL_REPO: find degraded peers, heal their repos.
 
@@ -434,10 +454,24 @@ class AutonomyEngine:
             task_mgr.update_task(task.id, status=TaskStatus.COMPLETED)
             return None
 
-        degraded = reaper.suspect_peers() + reaper.dead_peers()
-        if not degraded:
+        # 1 Task = 1 Peer: heal exactly the peer this task was created for
+        # (Command pattern — the task's target, not a blind global sweep).
+        target_id = self._extract_target_peer(getattr(task, "title", "") or "")
+        if target_id is None:
+            logger.warning(
+                "HEAL_REPO: could not extract target peer from title %r — skipping", getattr(task, "title", "")
+            )
             task_mgr.update_task(task.id, status=TaskStatus.COMPLETED)
             return None
+
+        target_peer = reaper.get_peer(target_id)
+        degraded_ids = {p.agent_id for p in (reaper.suspect_peers() + reaper.dead_peers())}
+        if target_peer is None or target_id not in degraded_ids:
+            # Peer recovered (or unknown) before we got here — nothing to heal.
+            logger.info("HEAL_REPO: peer %s no longer degraded — closing task", target_id)
+            task_mgr.update_task(task.id, status=TaskStatus.COMPLETED)
+            return None
+        degraded = [target_peer]
 
         healer = RepoHealer(
             pipeline=self.pipeline,
@@ -446,7 +480,7 @@ class AutonomyEngine:
         )
 
         results = []
-        for peer in degraded[:3]:
+        for peer in degraded:  # exactly the target peer (1 Task = 1 Peer)
             # Try local first, then remote clone
             repo_path = _resolve_peer_repo(peer.agent_id)
 

--- a/tests/test_autonomy_heal_target.py
+++ b/tests/test_autonomy_heal_target.py
@@ -1,0 +1,97 @@
+"""Flanke 3: HEAL_REPO heals exactly its target peer (1 Task = 1 Peer),
+not a blind degraded[:3] sweep. Command-vs-State-Mismatch fix."""
+
+from steward.autonomy import AutonomyEngine
+
+
+class TestExtractTargetPeer:
+    """The persistence-safe title parser must recover peer_ids, incl. hyphens."""
+
+    def test_simple_peer(self):
+        title = "[HEAL_REPO] Peer steward-test — Kirtan escalation"
+        assert AutonomyEngine._extract_target_peer(title) == "steward-test"
+
+    def test_hyphenated_peer(self):
+        title = "[HEAL_REPO] Peer agent-city — Kirtan escalation"
+        assert AutonomyEngine._extract_target_peer(title) == "agent-city"
+
+    def test_peer_without_suffix(self):
+        # no " — " delimiter → take rest of string
+        title = "[HEAL_REPO] Peer steward-gateway"
+        assert AutonomyEngine._extract_target_peer(title) == "steward-gateway"
+
+    def test_non_heal_title(self):
+        assert AutonomyEngine._extract_target_peer("[HEALTH_CHECK] something") is None
+
+    def test_garbage(self):
+        assert AutonomyEngine._extract_target_peer("no brackets here") is None
+
+
+class TestHealTargetsOnlyTaskPeer:
+    """Core fix: _execute_heal_repo heals ONLY the task's target peer,
+    even with multiple degraded peers (no blind degraded[:3] sweep)."""
+
+    def _run_heal(self, monkeypatch, target_title):
+        import asyncio
+        import time
+
+        import steward.autonomy as autonomy_mod
+        import steward.healer as healer_mod
+        from steward.reaper import HeartbeatReaper
+        from steward.services import SVC_REAPER
+        from vibe_core.di import ServiceRegistry
+
+        reaper = HeartbeatReaper(lease_ttl_s=900)
+        now = time.time()
+        for pid in ["agent-alpha", "steward-test", "agent-gamma"]:
+            reaper.record_heartbeat(agent_id=pid, source="setup")
+            reaper.get_peer(pid).last_seen = now - 999999
+        reaper.reap(now=now)
+        ServiceRegistry.register(SVC_REAPER, reaper)
+
+        healed = []
+
+        class _FakeResult:
+            findings_fixed = 0
+            findings_fixable = 0
+            pr_url = None
+            repo = "x"
+
+        class _FakeHealer:
+            def __init__(self, *a, **k):
+                pass
+
+            async def heal_repo(self, path):
+                healed.append(str(path))
+                return _FakeResult()
+
+        # RepoHealer is imported INSIDE the method via `from steward.healer import RepoHealer`
+        # → patch at the source module, not steward.autonomy
+        monkeypatch.setattr(healer_mod, "RepoHealer", _FakeHealer)
+        monkeypatch.setattr(autonomy_mod, "_resolve_peer_repo", lambda aid: aid)
+
+        class _Task:
+            id = "t1"
+            title = target_title
+
+        class _TM:
+            def update_task(self, *a, **k):
+                pass
+
+        class _Status:
+            COMPLETED = "COMPLETED"
+
+        eng = AutonomyEngine.__new__(AutonomyEngine)
+        eng.pipeline = type("P", (), {"_run_fn": staticmethod(lambda *a, **k: None)})()
+        eng._synaptic = None
+        eng._ledger = type("L", (), {"record_autonomous": staticmethod(lambda *a, **k: None)})()
+        asyncio.run(eng._execute_heal_repo(_Task(), _TM(), _Status()))
+        return healed
+
+    def test_heals_only_target_not_all_three(self, monkeypatch):
+        healed = self._run_heal(monkeypatch, "[HEAL_REPO] Peer steward-test — Kirtan escalation")
+        assert healed == ["steward-test"], f"expected only steward-test, got {healed}"
+
+    def test_targets_a_different_peer(self, monkeypatch):
+        healed = self._run_heal(monkeypatch, "[HEAL_REPO] Peer agent-gamma — Kirtan escalation")
+        assert healed == ["agent-gamma"], f"expected only agent-gamma, got {healed}"


### PR DESCRIPTION
## Problem
`_execute_heal_repo` ignored the task entirely and healed `suspect_peers() + dead_peers()[:3]` — a global sweep. A task created for a specific peer (`[HEAL_REPO] Peer X`) would heal the first 3 degraded peers instead of X. With many degraded nodes, peers 4+ **starved** while peers 1–3 got redundant PRs. Classic Command-vs-State mismatch.

## Fix
Extract the target peer_id from the task title (persistence-safe encoding, same pattern as `parse_intent_from_title`, hyphen-safe for ids like `steward-test`) and heal **exactly that peer**. If the peer recovered before dispatch, close the task cleanly — no false heal.

## Tests
5 parser unit tests + 2 integration tests (real `HeartbeatReaper`, faked `RepoHealer`) asserting only the target peer is healed among 3 degraded. **Mutation-proven**: restoring the `degraded[:3]` sweep turns the integration tests red. Full autonomy/heal/intent regression: 277 passed.

Note: includes a ruff-enforced import reordering in autonomy.py (no behavioural change). Separate from PR #62 (phantom TTL).