### PR TITLE
fix(reaper): deterministic trust on eviction (float drift + stale test/docstring)

### DIFF
--- a/steward/reaper.py
+++ b/steward/reaper.py
@@ -7,7 +7,7 @@ when peers die: lease expiration, trust degradation, slot reclamation.
 3-Strike Eviction Protocol:
     ALIVE   → missed 1 lease window → SUSPECT  (trust -= decay)
     SUSPECT → missed 2nd window     → DEAD     (trust -= decay, slots reclaimable)
-    DEAD    → missed 3rd window     → EVICTED  (trust = 0, purged from registry)
+    DEAD    → missed 3rd window     → EVICTED  (trust preserved — CI statelessness is not a trust violation; purged from active registry)
 
 The reaper is SOURCE-AGNOSTIC — any code can call record_heartbeat().
 Integration points:
@@ -47,7 +47,7 @@ class PeerStatus(enum.Enum):
     ALIVE = "alive"
     SUSPECT = "suspect"  # missed 1 lease window
     DEAD = "dead"  # missed 2+ windows
-    EVICTED = "evicted"  # trust = 0, purged
+    EVICTED = "evicted"  # trust preserved (CI-fair), purged from active set
 
 
 # Fingerprint stability threshold: N consecutive heartbeats with same
@@ -289,7 +289,7 @@ class HeartbeatReaper:
             old_trust = peer.trust
 
             peer.status = transition.next_status
-            peer.trust = max(0.0, peer.trust - self.trust_decay) if transition.decay else peer.trust  # preserve trust on eviction — CI statelessness ≠ defect
+            peer.trust = round(max(0.0, peer.trust - self.trust_decay), 10) if transition.decay else peer.trust  # preserve trust on eviction — CI statelessness ≠ defect
             detail = transition.detail_fn(age, self.lease_ttl_s)
 
             if transition.evict:

--- a/tests/test_reaper.py
+++ b/tests/test_reaper.py
@@ -115,7 +115,9 @@ class TestReaping:
         assert len(consequences) == 1
         c = consequences[0]
         assert c.action == "evict"
-        assert c.new_trust == 0.0
+        # Eviction PRESERVES trust (fix 4a7d55e7a0, 2026-03-30): CI statelessness
+        # is not a trust violation. 0.5 - 0.2 - 0.2 = 0.1 (rounded, no float drift).
+        assert c.new_trust == 0.1
         # Evicted peer kept in registry for persistence
         peer = reaper.get_peer("agent-a")
         assert peer is not None


### PR DESCRIPTION
## Problem
`test_dead_to_evicted_on_third_miss` failed stably: `0.09999999999999998 == 0.0`. Diagnosis showed **three** overlapping issues, not one:

1. **Float drift**: `0.5 - 0.2 - 0.2` accumulates to `0.0999…` instead of `0.1`. The value even leaks as float noise into trust reports (context_bridge).
2. **Stale docstrings**: they said "trust = 0, purged", but commit `4a7d55e7a0` (2026-03-30) deliberately changed eviction to **preserve** trust ("CI statelessness is not a trust violation"). The test and docstrings were never updated to match.
3. **Stale test**: still asserted the pre-fix `0.0`.

## Fix
`round(…, 10)` at the decrement source (matches the protocol's no-raw-float hygiene) → clean `0.1`. Docstrings corrected to the preserve-trust semantics. Test updated to `== 0.1` with a comment pointing at the design commit.

## Proof
Mutation-proven: removing the `round()` turns the test red (`0.0999… != 0.1`). Full test_reaper 36/36; regression across reaper/federation/autonomy/dharma 260 green.