### PR TITLE
fix(dharma): surface silent federation-read failures instead of swallowing them

### DIFF
--- a/steward/hooks/dharma.py
+++ b/steward/hooks/dharma.py
@@ -291,7 +291,13 @@ class DharmaFederationHook(BasePhaseHook):
             try:
                 data = json.loads(peer_path.read_text())
                 self._capabilities = tuple(data.get("capabilities", []))
-            except (json.JSONDecodeError, OSError):
+            except json.JSONDecodeError as e:
+                logger.warning("DHARMA: peer.json is corrupt — treating peer as capability-less: %s", e)
+                self._capabilities = ()
+            except OSError as e:
+                logger.warning(
+                    "DHARMA: could not read peer.json (%s) — treating peer as capability-less", type(e).__name__
+                )
                 self._capabilities = ()
         else:
             self._capabilities = ()
@@ -411,8 +417,12 @@ class DharmaFederationHook(BasePhaseHook):
                             len(recorded),
                             ", ".join(sorted(recorded)),
                         )
-            except (json.JSONDecodeError, OSError):
-                pass
+            except (json.JSONDecodeError, OSError) as e:
+                # Was silently swallowed — a corrupt/unreadable inbox made the whole
+                # federation look silent with no trace. Behaviour unchanged (skip this
+                # cycle's inbox), but now visible. Narrowing the try scope is tracked
+                # separately (the block also wraps record_heartbeat).
+                logger.error("DHARMA: could not process nadi_inbox (%s) — skipping this cycle: %s", type(e).__name__, e)
 
         # Check for stale delivery receipts — messages that were pushed
         # but never implicitly confirmed by a response from the target.


### PR DESCRIPTION
## Problem
Two `except` handlers hid failures with no trace:

1. **Critical**: `execute()` wrapped nadi_inbox processing in `except (JSONDecodeError, OSError): pass`. A corrupt or unreadable inbox made the whole federation look silent — the Steward processed no heartbeats and logged **nothing**. This is exactly the kind of invisible failure that masquerades as a normal empty state.
2. `_get_capabilities()` swallowed a corrupt/missing peer.json into an empty tuple silently.

## Fix
1. nadi_inbox failures now log at **ERROR**. Control flow unchanged (a bad inbox is still skipped for that cycle) — only visibility is added.
2. peer.json now distinguishes a corrupt file (WARNING with detail) from an unreadable one, same graceful fallback.

**No behavioural change** — corrupt reads produce the same empty results as before, but are now visible in logs. Regression: 216 green.

## Deliberately out of scope (tracked separately)
The nadi_inbox `try` is over-broad (it also wraps `record_heartbeat`). Narrowing it changes error propagation, so it's left for its own change with caller tests. Same for wiring `ctx.health_anomaly` on inbox failure — surface first, react later.