### PR TITLE
fix(federation): register verified agent_claim peers in reaper

### DIFF
--- a/steward/federation.py
+++ b/steward/federation.py
@@ -1240,6 +1240,14 @@ class FederationBridge:
             and existing.get("agent_name") == agent_name
             and existing_caps == normalized_caps
         )
+        # Gatekeeper informs the doctor: a verified claim proves this peer exists.
+        # Key by agent_name (human identity), NOT node_id — crypto keys rotate,
+        # so multiple node_ids map to one agent (see verified_agents.json). This
+        # runs BEFORE the unchanged-shortcut so idempotent re-claims still keep
+        # the peer fresh in the reaper (otherwise a stable node would starve).
+        if self.reaper is not None and agent_name:
+            self.reaper.record_heartbeat(agent_id=agent_name, source="agent_claim")
+
         if unchanged:
             logger.info(
                 "BRIDGE: agent_claim identical — node_id=%s skipped (no registry write)",

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -1519,3 +1519,43 @@ class TestBottleneckResolutionEmitter:
         hook.execute(ctx)
 
         assert len(bridge._outbound) == 0
+
+
+class TestAgentClaimRegistersPeerInReaper:
+    """MUTATION PROOF: a verified agent_claim must make the peer known to the
+    Reaper (keyed by agent_name), so dharma.py's _peers gate lets its
+    subsequent ag_ heartbeats through. Without the fix, peers stay [] and
+    named nodes freeze at 91 days despite live claims."""
+
+    def test_agent_claim_registers_peer_alive_by_agent_name(self, tmp_path):
+        from steward.federation import OP_AGENT_CLAIM, FederationBridge, derive_node_id
+        from steward.reaper import HeartbeatReaper
+
+        reaper = HeartbeatReaper()
+        bridge = FederationBridge(
+            agent_id="steward",
+            reaper=reaper,
+            verified_agents_path=tmp_path / "verified_agents.json",
+        )
+        public_key = "ecdsa-pub-city-001"
+        node_id = derive_node_id(public_key)
+
+        assert reaper.peer_count() == 0
+
+        assert bridge.ingest(
+            OP_AGENT_CLAIM,
+            {
+                "agent_name": "agent-city",
+                "node_id": node_id,
+                "public_key": public_key,
+                "capabilities": ["city_governance"],
+            },
+        )
+
+        # Peer must now be known to the reaper, keyed by CLARNAME not hash
+        assert reaper.get_peer("agent-city") is not None, "claim did not register peer in reaper"
+        assert reaper.peer_count() == 1
+        alive_names = {p.agent_id for p in reaper.alive_peers()}
+        assert "agent-city" in alive_names
+        # must NOT be keyed by the crypto hash
+        assert reaper.get_peer(node_id) is None


### PR DESCRIPTION
## Problem

Named federation nodes (agent-city, agent-research, steward-federation) sent 84 valid `agent_claim` messages that upserted `verified_agents.json` but never registered the peer in the reaper. dharma.py's `_peers` gate then dropped every subsequent `ag_` heartbeat (`peer not in reaper._peers`), freezing named nodes at 91 days old in `nadi_inbox.json` despite live claims and heartbeats.

Root cause: a bootstrap deadlock. The claim was supposed to make the peer known, but only wrote to the gatekeeper registry — the reaper (`_peers`) stayed empty (`peers.json: []`, total_reaps 4441), so every named heartbeat failed the membership gate.

## Fix

In `_handle_agent_claim`, after the `node_id == derive_node_id(public_key)` validation, the gatekeeper informs the reaper via `record_heartbeat`.

- **Keyed by `agent_name`, not `node_id`** — crypto keys rotate; multiple node_ids map to one agent (verified_agents.json holds 3 node_ids for steward-federation). Hash-keying would create ghost peers.
- **Runs before the idempotency shortcut** — otherwise a stable node whose re-claims are identical would never refresh and would starve.
- **Layering preserved**: gatekeeper (federation.py) notifies the doctor (reaper.py) without owning peer state.

## Mutation proof

`TestAgentClaimRegistersPeerInReaper`: red without the fix (peers stay empty), green with it. 108/109 pass. The one red test (`test_dead_to_evicted_on_third_miss`, reaper trust float) is pre-existing on main — verified via stash that it fails without this change — and is fixed separately in #64.

## Note on blocked delivery chain

This fixes Path 1 (dharma/nadi_inbox via claim). Paths 2 and 3 (federation.py:452, _handle_heartbeat) use different identity extraction and may need a shared resolver — separate follow-up, not this PR. PR #62 (phantom-TTL) stays blocked until live delivery confirms named nodes arrive fresh.