### PR TITLE
fix: route canonical federation input through gateway

### DIFF
--- a/steward/federation.py
+++ b/steward/federation.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
-from steward.federation_crypto import derive_node_id, sign_payload_hash
+from steward.federation_crypto import canonical_message_hash, derive_node_id, sign_payload_hash
 from vibe_core.mahamantra.federation.types import FederationMessage
 
 logger = logging.getLogger("STEWARD.FEDERATION")
@@ -515,8 +515,8 @@ class FederationBridge:
         steward-federation/nadi_kit's _sign_message — wire format compatible
         with steward.federation_crypto.verify_payload_signature.
         """
-        canonical = {k: v for k, v in msg.items() if k not in ("payload_hash", "signature")}
-        payload_hash = hashlib.sha256(json.dumps(canonical, sort_keys=True).encode("utf-8")).hexdigest()
+        canonical = {k: v for k, v in msg.items() if k not in ("payload_hash", "signature", "signer_key")}
+        payload_hash = canonical_message_hash(canonical)
         signature = sign_payload_hash(identity["private_key"], payload_hash)
         return {**canonical, "payload_hash": payload_hash, "signature": signature}
 

--- a/steward/federation_crypto.py
+++ b/steward/federation_crypto.py
@@ -12,10 +12,32 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey,
 
 logger = logging.getLogger("STEWARD.FEDERATION_CRYPTO")
 
+_MESSAGE_INTEGRITY_FIELDS = frozenset({"payload_hash", "signature", "signer_key"})
+
 
 def derive_node_id(public_key_hex: str, length: int = 16) -> str:
     digest = hashlib.sha256(str(public_key_hex).encode()).hexdigest()
     return f"ag_{digest[:length]}"
+
+
+def canonical_message_hash(message: dict, *, exclude_hub_id: bool = False) -> str:
+    excluded = set(_MESSAGE_INTEGRITY_FIELDS)
+    if exclude_hub_id:
+        excluded.add("id")
+    canonical = {key: value for key, value in message.items() if key not in excluded}
+    encoded = json.dumps(canonical, sort_keys=True, default=str)
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def inbound_message_hash_format(message: dict) -> str | None:
+    expected_hash = str(message.get("payload_hash", "")).strip()
+    if not expected_hash:
+        return None
+    if canonical_message_hash(message) == expected_hash:
+        return "canonical"
+    if "id" in message and canonical_message_hash(message, exclude_hub_id=True) == expected_hash:
+        return "canonical_pre_hub_id"
+    return None
 
 
 def _load_from_hex_or_json(text: str) -> tuple[str, str, str] | None:

--- a/steward/federation_gateway.py
+++ b/steward/federation_gateway.py
@@ -92,10 +92,9 @@ class GatewayStats:
         }
 
 
-# Replay protection — sliding timestamp window + per-source LRU of seen hashes.
-# Window is generous enough to absorb clock skew and NADI relay latency, tight
-# enough that an attacker cannot stockpile signed messages.
-_REPLAY_WINDOW_S: float = 300.0  # ±5 minutes
+# Replay protection — federation-TTL window + per-source LRU of seen hashes.
+# The relay cadence is 15 minutes, so the window must cover multiple cycles.
+_REPLAY_WINDOW_S: float = 7200.0
 _REPLAY_CACHE_PER_SOURCE: int = 256  # LRU size per source — bounds memory
 
 
@@ -405,6 +404,8 @@ class FederationGateway(GatewayProtocol):
             # Verify node_id matches derived ID from public_key (prevent tampering)
             if derive_node_id(public_key) != node_id:
                 return False, "identity_spoofing_attempt", "gateway_authorization"
+            if str(msg.get("source", "")).strip() != node_id:
+                return False, "identity_spoofing_attempt", "gateway_authorization"
             # Proof of possession: the claim must be signed with the very key it
             # claims. Without this, anyone who can drop a message into the hub can
             # register under any agent_name with a key they just made up — and the
@@ -418,17 +419,9 @@ class FederationGateway(GatewayProtocol):
             payload_hash = str(msg.get("payload_hash", "")).strip()
             signature = str(msg.get("signature", "")).strip()
             if not payload_hash or not signature:
-                logger.warning(
-                    "GATEWAY: agent_claim from %s carries no signature — "
-                    "proof of possession missing (not yet enforced)",
-                    node_id,
-                )
+                return False, "claim_proof_missing", "gateway_authorization"
             elif not verify_payload_signature(public_key, payload_hash, signature):
-                logger.warning(
-                    "GATEWAY: agent_claim from %s failed proof of possession — "
-                    "signature does not match the claimed public key (not yet enforced)",
-                    node_id,
-                )
+                return False, "claim_proof_invalid", "gateway_authorization"
             else:
                 logger.info("GATEWAY: agent_claim from %s proved possession of its key", node_id)
         if operation in PUBLIC_OPERATIONS:
@@ -503,6 +496,15 @@ class FederationGateway(GatewayProtocol):
             logger.warning("GATEWAY: read_outbox failed: %s", e)
             self._stats.errors += 1
             return 0
+
+        messages = sorted(
+            messages,
+            key=lambda message: (
+                0
+                if isinstance(message, dict) and message.get("operation") == "federation.agent_claim"
+                else 1
+            ),
+        )
 
         processed = 0
         for msg in messages:
@@ -623,6 +625,18 @@ class FederationGateway(GatewayProtocol):
                     "operation": msg.get("operation", ""),
                 },
             )
+        if messages and hasattr(transport, "remove_inbox_messages"):
+            try:
+                removed = transport.remove_inbox_messages(messages)
+                if isinstance(removed, int):
+                    logger.info(
+                        "GATEWAY INBOUND: consumed %d terminal message(s), removed %d from inbox",
+                        len(messages),
+                        removed,
+                    )
+            except Exception:
+                self._stats.errors += 1
+                logger.exception("GATEWAY INBOUND: failed to remove terminal messages from inbox")
         return processed
 
     # ── Observability ─────────────────────────────────────────────

--- a/steward/federation_transport.py
+++ b/steward/federation_transport.py
@@ -26,7 +26,12 @@ import time
 import uuid
 from pathlib import Path
 
-from steward.federation_crypto import NodeKeyStore, sign_payload_hash
+from steward.federation_crypto import (
+    NodeKeyStore,
+    canonical_message_hash,
+    inbound_message_hash_format,
+    sign_payload_hash,
+)
 from vibe_core.mahamantra.federation.types import FederationMessage
 
 logger = logging.getLogger("STEWARD.FEDERATION.TRANSPORT")
@@ -80,13 +85,8 @@ class NadiFederationTransport:
         encoded = json.dumps(payload, sort_keys=True, default=str)
         return hashlib.sha256(encoded.encode()).hexdigest()
 
-    def _payload_hash(self, payload: object) -> str:
-        serialized = self._serialize_message(payload)
-        encoded = json.dumps(serialized, sort_keys=True, default=str)
-        return hashlib.sha256(encoded.encode()).hexdigest()
-
     def _with_integrity_fields(self, payload: dict) -> dict:
-        """Attach integrity fields (legacy path) UNLESS the message is
+        """Attach canonical integrity fields UNLESS the message is
         already signed by an upstream layer.
 
         FederationBridge.flush_outbound (TICKET-007 #54) signs every
@@ -96,20 +96,17 @@ class NadiFederationTransport:
         three fields are populated, this transport must NOT overwrite
         them — doing so produced ghost-identity emissions for cycles.
 
-        The legacy file-based-key path is preserved only for messages
+        The file-based-key path is preserved only for messages
         that arrive without signing (back-compat for any code that
         still constructs raw FederationMessage dicts and hands them to
         the transport directly).
         """
         enriched = dict(payload)
         if enriched.get("source") and enriched.get("payload_hash") and enriched.get("signature"):
-            # Pre-signed by FederationBridge — only stamp a message_id if missing.
-            enriched.setdefault("message_id", str(uuid.uuid4()))
             return enriched
-        # Legacy path: payload-scoped hash, transport signs with file-based key
         enriched["source"] = self.node_id
         enriched["message_id"] = str(uuid.uuid4())
-        enriched["payload_hash"] = self._payload_hash(enriched.get("payload", {}))
+        enriched["payload_hash"] = canonical_message_hash(enriched)
         enriched["signature"] = sign_payload_hash(self.private_key, enriched["payload_hash"])
         return enriched
 
@@ -301,8 +298,7 @@ class NadiFederationTransport:
                         continue
                 expected_hash = str(item.get("payload_hash", "")).strip()
                 if expected_hash:
-                    actual_hash = self._payload_hash(item.get("payload", {}))
-                    if actual_hash != expected_hash:
+                    if inbound_message_hash_format(item) is None:
                         self.quarantine_messages(
                             [item],
                             reason="integrity_check_failed",

--- a/steward/hooks/dharma.py
+++ b/steward/hooks/dharma.py
@@ -7,8 +7,10 @@ observe health → reap dead peers → purge expired slots → broadcast heartbe
 
 from __future__ import annotations
 
+import json
 import logging
 import time
+from pathlib import Path
 
 from steward.hooks.genesis import _get_federation_owner
 from steward.phase_hook import DHARMA, BasePhaseHook, PhaseContext
@@ -349,26 +351,6 @@ class DharmaFederationHook(BasePhaseHook):
         if git_sync is not None:
             git_sync.pull()
 
-        # Process inbound messages: agent_claim + heartbeats
-        import json
-        from pathlib import Path
-
-        inbox_path = Path("data/federation/nadi_inbox.json")
-        if inbox_path.exists():
-            try:
-                messages = json.loads(inbox_path.read_text())
-                reaper = ServiceRegistry.get(SVC_REAPER)
-                federation = ServiceRegistry.get(SVC_FEDERATION)
-                transport = ServiceRegistry.get(SVC_FEDERATION_TRANSPORT)
-                if reaper is not None and federation is not None:
-                    self._process_inbox_messages(messages, reaper, federation, transport)
-            except (json.JSONDecodeError, OSError) as e:
-                # Was silently swallowed — a corrupt/unreadable inbox made the whole
-                # federation look silent with no trace. Behaviour unchanged (skip this
-                # cycle's inbox), but now visible. Narrowing the try scope is tracked
-                # separately (the block also wraps record_heartbeat).
-                logger.error("DHARMA: could not process nadi_inbox (%s) — skipping this cycle: %s", type(e).__name__, e)
-
         # Check for stale delivery receipts — messages that were pushed
         # but never implicitly confirmed by a response from the target.
         # This closes the fire-and-forget gap: agent-internet defines
@@ -436,12 +418,9 @@ class DharmaFederationHook(BasePhaseHook):
         # forever, and the inbox never shrinks (Befund 207).
         rejected: list = []
         seen_bad = getattr(transport, "_quarantined", set()) if transport is not None else set()
-        # Process agent_claim messages first (cryptographic identity)
         for msg in messages:
-            if msg.get("operation") == "federation.agent_claim":
-                federation.ingest("federation.agent_claim", msg.get("payload", msg))
-        # Then record heartbeats
-        for msg in messages:
+            if msg.get("operation") != "heartbeat":
+                continue
             # Prefer agent_id (human-readable identity) over source (node crypto ID)
             # Already refused in an earlier cycle: drop it without re-checking or
             # re-logging, but make sure it leaves the inbox this time.

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -1647,7 +1647,7 @@ class TestFederationInboxTTLFilter:
         DharmaFederationHook()._process_inbox_messages([msg], r, None)
         assert r.get_peer("phantom-no-ts").last_seen == base
 
-    def test_agent_claim_unaffected_by_ttl(self):
+    def test_agent_claim_is_left_for_gateway(self):
         import time
 
         from steward.hooks.dharma import DharmaFederationHook
@@ -1670,4 +1670,4 @@ class TestFederationInboxTTLFilter:
             "timestamp": time.time() - 99999.0,
         }
         DharmaFederationHook()._process_inbox_messages([claim], HeartbeatReaper(), fed)
-        assert fed.ingested == [("federation.agent_claim", {"agent_id": "claimant"})]
+        assert fed.ingested == []

--- a/tests/test_federation_gateway.py
+++ b/tests/test_federation_gateway.py
@@ -7,7 +7,7 @@ import json
 from unittest.mock import MagicMock
 
 from steward.federation import FederationBridge
-from steward.federation_crypto import NodeKeyStore, sign_payload_hash
+from steward.federation_crypto import NodeKeyStore, canonical_message_hash, sign_payload_hash
 from steward.federation_gateway import FederationGateway, _is_a2a, _is_nadi
 from steward.federation_transport import NadiFederationTransport
 from steward.services import SVC_TASK_MANAGER
@@ -524,22 +524,15 @@ class TestProcessInbound:
             "reward": 108,
             "description": "Fix CI",
         }
-        (tmp_path / "nadi_inbox.json").write_text(
-            json.dumps(
-                [
-                    {
-                        "source": "node-x",
-                        "target": "steward",
-                        "operation": "governance_bounty",
-                        "payload": payload,
-                        "message_id": "gov-1",
-                        "payload_hash": __import__("hashlib")
-                        .sha256(json.dumps(payload, sort_keys=True).encode())
-                        .hexdigest(),
-                    }
-                ]
-            )
-        )
+        message = {
+            "source": "node-x",
+            "target": "steward",
+            "operation": "governance_bounty",
+            "payload": payload,
+            "message_id": "gov-1",
+        }
+        message["payload_hash"] = canonical_message_hash(message)
+        (tmp_path / "nadi_inbox.json").write_text(json.dumps([message]))
         bridge = FederationBridge(agent_id="steward", verified_agents_path=tmp_path / "verified_agents.json")
         gw = FederationGateway(bridge=bridge)
 
@@ -554,6 +547,7 @@ class TestProcessInbound:
         # the signature against, so we must reject.
         assert record["stage"] == "crypto_verification"
         assert record["reason"] == "unknown_sender"
+        assert json.loads((tmp_path / "nadi_inbox.json").read_text()) == []
 
     def test_unverified_sender_public_operation_is_allowed(self, tmp_path):
         transport = NadiFederationTransport(str(tmp_path))
@@ -568,22 +562,17 @@ class TestProcessInbound:
             "public_key": node_x_keys.public_key,
             "capabilities": ["infra"],
         }
-        (tmp_path / "nadi_inbox.json").write_text(
-            json.dumps(
-                [
-                    {
-                        "source": node_x_keys.node_id,
-                        "target": "steward",
-                        "operation": "federation.agent_claim",
-                        "payload": payload,
-                        "message_id": "claim-1",
-                        "payload_hash": __import__("hashlib")
-                        .sha256(json.dumps(payload, sort_keys=True).encode())
-                        .hexdigest(),
-                    }
-                ]
-            )
+        message = _sign_outbound(
+            {
+                "source": node_x_keys.node_id,
+                "target": "steward",
+                "operation": "federation.agent_claim",
+                "payload": payload,
+                "message_id": "claim-1",
+            },
+            node_x_keys,
         )
+        (tmp_path / "nadi_inbox.json").write_text(json.dumps([message]))
         bridge = FederationBridge(agent_id="steward", verified_agents_path=tmp_path / "verified_agents.json")
         gw = FederationGateway(bridge=bridge)
 
@@ -621,16 +610,16 @@ class TestProcessInbound:
         (tmp_path / "nadi_inbox.json").write_text(
             json.dumps(
                 [
-                    {
-                        "source": node_x_keys.node_id,
-                        "target": "steward",
-                        "operation": "governance_bounty",
-                        "payload": gov_payload,
-                        "message_id": "gov-a",
-                        "payload_hash": __import__("hashlib")
-                        .sha256(json.dumps(gov_payload, sort_keys=True).encode())
-                        .hexdigest(),
-                    }
+                    _sign_outbound(
+                        {
+                            "source": node_x_keys.node_id,
+                            "target": "steward",
+                            "operation": "governance_bounty",
+                            "payload": gov_payload,
+                            "message_id": "gov-a",
+                        },
+                        node_x_keys,
+                    )
                 ]
             )
         )
@@ -639,16 +628,16 @@ class TestProcessInbound:
         (tmp_path / "nadi_inbox.json").write_text(
             json.dumps(
                 [
-                    {
-                        "source": node_x_keys.node_id,
-                        "target": "steward",
-                        "operation": "federation.agent_claim",
-                        "payload": claim_payload,
-                        "message_id": "claim-b",
-                        "payload_hash": __import__("hashlib")
-                        .sha256(json.dumps(claim_payload, sort_keys=True).encode())
-                        .hexdigest(),
-                    }
+                    _sign_outbound(
+                        {
+                            "source": node_x_keys.node_id,
+                            "target": "steward",
+                            "operation": "federation.agent_claim",
+                            "payload": claim_payload,
+                            "message_id": "claim-b",
+                        },
+                        node_x_keys,
+                    )
                 ]
             )
         )
@@ -657,21 +646,16 @@ class TestProcessInbound:
         (tmp_path / "nadi_inbox.json").write_text(
             json.dumps(
                 [
-                    {
-                        "source": node_x_keys.node_id,
-                        "target": "steward",
-                        "operation": "governance_bounty",
-                        "payload": gov_payload,
-                        "message_id": "gov-c",
-                        "timestamp": __import__("time").time(),
-                        "payload_hash": __import__("hashlib")
-                        .sha256(json.dumps(gov_payload, sort_keys=True).encode())
-                        .hexdigest(),
-                        "signature": sign_payload_hash(
-                            node_x_keys.private_key,
-                            __import__("hashlib").sha256(json.dumps(gov_payload, sort_keys=True).encode()).hexdigest(),
-                        ),
-                    }
+                    _sign_outbound(
+                        {
+                            "source": node_x_keys.node_id,
+                            "target": "steward",
+                            "operation": "governance_bounty",
+                            "payload": gov_payload,
+                            "message_id": "gov-c",
+                        },
+                        node_x_keys,
+                    )
                 ]
             )
         )
@@ -703,23 +687,16 @@ class TestProcessInbound:
             "reward": 108,
             "description": "Fix CI",
         }
-        (tmp_path / "nadi_inbox.json").write_text(
-            json.dumps(
-                [
-                    {
-                        "source": node_x_keys.node_id,
-                        "target": "steward",
-                        "operation": "governance_bounty",
-                        "payload": gov_payload,
-                        "message_id": "gov-bad",
-                        "payload_hash": __import__("hashlib")
-                        .sha256(json.dumps(gov_payload, sort_keys=True).encode())
-                        .hexdigest(),
-                        "signature": "deadbeef",
-                    }
-                ]
-            )
-        )
+        message = {
+            "source": node_x_keys.node_id,
+            "target": "steward",
+            "operation": "governance_bounty",
+            "payload": gov_payload,
+            "message_id": "gov-bad",
+        }
+        message["payload_hash"] = canonical_message_hash(message)
+        message["signature"] = "deadbeef"
+        (tmp_path / "nadi_inbox.json").write_text(json.dumps([message]))
         bridge = FederationBridge(agent_id="steward", verified_agents_path=tmp_path / "verified_agents.json")
         gw = FederationGateway(bridge=bridge)
 
@@ -780,14 +757,16 @@ class TestProcessInbound:
             "public_key": node_a_keys.public_key,
             "capabilities": ["bounty_hunter", "infrastructure"],
         }
-        message = {
-            "source": node_a_keys.node_id,
-            "target": "node-b",
-            "operation": "federation.agent_claim",
-            "payload": payload,
-            "message_id": "claim-1",
-            "payload_hash": __import__("hashlib").sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest(),
-        }
+        message = _sign_outbound(
+            {
+                "source": node_a_keys.node_id,
+                "target": "node-b",
+                "operation": "federation.agent_claim",
+                "payload": payload,
+                "message_id": "claim-1",
+            },
+            node_a_keys,
+        )
         (node_b / "nadi_inbox.json").write_text(json.dumps([message]))
 
         processed = gw_b.process_inbound(transport_b)
@@ -797,6 +776,75 @@ class TestProcessInbound:
         assert registry[node_a_keys.node_id]["public_key"] == node_a_keys.public_key
         # Capabilities are normalised (set + sort) by the handler now
         assert sorted(registry[node_a_keys.node_id]["capabilities"]) == ["bounty_hunter", "infrastructure"]
+
+    def test_real_dharma_transport_gateway_claim_then_city_report(self, tmp_path):
+        from steward.hooks.dharma import DharmaFederationHook
+        from steward.reaper import HeartbeatReaper
+
+        transport = NadiFederationTransport(str(tmp_path))
+        node_keys = NodeKeyStore(tmp_path / "agent-city" / ".node_keys.json")
+        node_keys.ensure_keys()
+        reaper = HeartbeatReaper()
+        bridge = FederationBridge(
+            agent_id="steward",
+            reaper=reaper,
+            verified_agents_path=tmp_path / "verified_agents.json",
+        )
+        gateway = FederationGateway(bridge=bridge, reaper=reaper)
+        claim = _sign_outbound(
+            {
+                "id": "claim-signed-by-nadi-kit",
+                "source": node_keys.node_id,
+                "target": "steward",
+                "operation": "federation.agent_claim",
+                "payload": {
+                    "agent_name": "agent-city",
+                    "node_id": node_keys.node_id,
+                    "public_key": node_keys.public_key,
+                    "capabilities": ["city_governance"],
+                },
+            },
+            node_keys,
+        )
+        report = _sign_outbound(
+            {
+                "source": node_keys.node_id,
+                "target": "steward",
+                "operation": "city_report",
+                "payload": {
+                    "alive": 3,
+                    "population": 3,
+                    "chain_valid": True,
+                    "heartbeat": 42,
+                    "mission_results": [],
+                    "pr_results": [],
+                    "active_campaigns": [],
+                    "origin_phase": "moksha",
+                },
+                "priority": 1,
+                "correlation_id": "",
+                "ttl_s": 7200.0,
+            },
+            node_keys,
+        )
+        report["id"] = "hub-added-after-signing"
+        messages = [report, claim]
+        inbox = tmp_path / "nadi_inbox.json"
+        inbox.write_text(json.dumps(messages))
+
+        DharmaFederationHook()._process_inbox_messages(messages, reaper, bridge, transport)
+
+        assert not (tmp_path / "verified_agents.json").exists()
+        assert json.loads(inbox.read_text()) == messages
+        assert gateway.process_inbound(transport) == 2
+        assert json.loads(inbox.read_text()) == []
+        registry = json.loads((tmp_path / "verified_agents.json").read_text())
+        assert registry[node_keys.node_id]["public_key"] == node_keys.public_key
+        assert reaper.get_peer("agent-city") is not None
+        quarantine_records = [
+            path for path in (tmp_path / "quarantine").glob("*.json") if path.name != "index.json"
+        ]
+        assert quarantine_records == []
 
     def test_spoofed_agent_claim_is_quarantined_for_identity_spoofing(self, tmp_path):
         node_b = tmp_path / "node-b"
@@ -812,18 +860,16 @@ class TestProcessInbound:
             "public_key": attacker_keys.public_key,
             "capabilities": ["governance"],
         }
-        message = {
-            "source": "ag_world_gov",
-            "target": "node-b",
-            "operation": "federation.agent_claim",
-            "payload": payload,
-            "message_id": "claim-spoof",
-            "payload_hash": __import__("hashlib").sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest(),
-            "signature": sign_payload_hash(
-                attacker_keys.private_key,
-                __import__("hashlib").sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest(),
-            ),
-        }
+        message = _sign_outbound(
+            {
+                "source": "ag_world_gov",
+                "target": "node-b",
+                "operation": "federation.agent_claim",
+                "payload": payload,
+                "message_id": "claim-spoof",
+            },
+            attacker_keys,
+        )
         (node_b / "nadi_inbox.json").write_text(json.dumps([message]))
 
         assert gw_b.process_inbound(transport_b) == 0
@@ -893,15 +939,34 @@ class TestReplayProtection:
         keys.ensure_keys()
         bridge = _verified_mock_bridge(keys)
         gw = FederationGateway(bridge=bridge)
-        # Timestamp 1 hour in the past — outside the ±5min window
+        # Timestamp 3 hours in the past — outside the federation TTL window
         stale = _sign_outbound(
-            {"operation": "heartbeat", "source": keys.node_id, "payload": {}, "timestamp": time.time() - 3600},
+            {"operation": "heartbeat", "source": keys.node_id, "payload": {}, "timestamp": time.time() - 10800},
             keys,
         )
         processed = gw.process_inbound(self._make_transport([stale]))
 
         assert processed == 0
         bridge.ingest.assert_not_called()
+
+    def test_message_delayed_by_heartbeat_cadence_is_allowed(self, tmp_path):
+        keys = NodeKeyStore(tmp_path / "k" / ".node_keys.json")
+        keys.ensure_keys()
+        bridge = _verified_mock_bridge(keys)
+        gw = FederationGateway(bridge=bridge)
+        delayed = _sign_outbound(
+            {
+                "operation": "heartbeat",
+                "source": keys.node_id,
+                "payload": {},
+                "timestamp": time.time() - 900,
+                "ttl_s": 7200.0,
+            },
+            keys,
+        )
+
+        assert gw.process_inbound(self._make_transport([delayed])) == 1
+        bridge.ingest.assert_called_once()
 
     def test_message_without_timestamp_is_blocked(self, tmp_path):
         keys = NodeKeyStore(tmp_path / "k" / ".node_keys.json")
@@ -930,8 +995,30 @@ class TestReplayProtection:
         keys.ensure_keys()
         bridge = _verified_mock_bridge(keys)
         gw = FederationGateway(bridge=bridge)
-        # No timestamp, no signature — agent_claim is bootstrap and not subject
-        # to replay protection (it's idempotent at the handler level)
+        claim = _sign_outbound(
+            {
+                "operation": "federation.agent_claim",
+                "source": keys.node_id,
+                "payload": {
+                    "agent_name": "k",
+                    "node_id": keys.node_id,
+                    "public_key": keys.public_key,
+                    "capabilities": [],
+                },
+            },
+            keys,
+        )
+        # Send twice: second should still be accepted at the gateway level
+        # (the handler dedupes by node_id + content hash internally)
+        transport = self._make_transport([claim, claim])
+        processed = gw.process_inbound(transport)
+        assert processed == 2
+
+    def test_unsigned_agent_claim_is_rejected(self, tmp_path):
+        keys = NodeKeyStore(tmp_path / "k" / ".node_keys.json")
+        keys.ensure_keys()
+        bridge = _verified_mock_bridge(keys)
+        gw = FederationGateway(bridge=bridge)
         claim = {
             "operation": "federation.agent_claim",
             "source": keys.node_id,
@@ -942,11 +1029,9 @@ class TestReplayProtection:
                 "capabilities": [],
             },
         }
-        # Send twice: second should still be accepted at the gateway level
-        # (the handler dedupes by node_id + content hash internally)
-        transport = self._make_transport([claim, claim])
-        processed = gw.process_inbound(transport)
-        assert processed == 2
+
+        assert gw.process_inbound(self._make_transport([claim])) == 0
+        bridge.ingest.assert_not_called()
 
 
 import time  # noqa: E402  — used only by replay tests above

--- a/tests/test_federation_transport.py
+++ b/tests/test_federation_transport.py
@@ -231,6 +231,50 @@ class TestNadiFederationTransport:
         assert record["stage"] == "transport_inbound_verify"
         assert record["reason"] == "integrity_check_failed"
 
+    def test_read_outbox_accepts_canonical_message_hash_before_hub_id(self, tmp_path):
+        transport = NadiFederationTransport(str(tmp_path))
+        canonical = {
+            "source": "ag_sender",
+            "target": "steward",
+            "operation": "city_report",
+            "payload": {"alive": 3, "chain_valid": True},
+            "priority": 1,
+            "correlation_id": "",
+            "timestamp": time.time(),
+            "ttl_s": 7200.0,
+        }
+        payload_hash = hashlib.sha256(json.dumps(canonical, sort_keys=True).encode()).hexdigest()
+        delivered = {
+            **canonical,
+            "payload_hash": payload_hash,
+            "signature": "signed-upstream",
+            "id": "hub-added-after-signing",
+        }
+        (tmp_path / "nadi_inbox.json").write_text(json.dumps([delivered]))
+
+        assert transport.read_outbox() == [delivered]
+
+    def test_read_outbox_rejects_tampered_canonical_envelope(self, tmp_path):
+        transport = NadiFederationTransport(str(tmp_path))
+        canonical = {
+            "source": "ag_sender",
+            "target": "steward",
+            "operation": "city_report",
+            "payload": {"alive": 3, "chain_valid": True},
+            "timestamp": time.time(),
+            "ttl_s": 7200.0,
+        }
+        payload_hash = hashlib.sha256(json.dumps(canonical, sort_keys=True).encode()).hexdigest()
+        tampered = {
+            **canonical,
+            "operation": "governance_bounty",
+            "payload_hash": payload_hash,
+            "signature": "signed-upstream",
+        }
+        (tmp_path / "nadi_inbox.json").write_text(json.dumps([tampered]))
+
+        assert transport.read_outbox() == []
+
     def test_round_trip_via_nadi_files(self, tmp_path):
         """Write outbound, simulate inbound, read back."""
         transport = NadiFederationTransport(str(tmp_path))
@@ -250,19 +294,16 @@ class TestNadiFederationTransport:
         # Simulate another agent delivering messages to our inbox
         inbox_path = tmp_path / "nadi_inbox.json"
         payload = {"task_title": "fix tests", "pr_url": "https://github.com/test/pr/1"}
+        inbound = {
+            "source": "agent-city",
+            "target": "steward",
+            "operation": "task_completed",
+            "payload": payload,
+            "message_id": "msg-1",
+        }
+        inbound["payload_hash"] = hashlib.sha256(json.dumps(inbound, sort_keys=True).encode()).hexdigest()
         inbox_path.write_text(
-            json.dumps(
-                [
-                    {
-                        "source": "agent-city",
-                        "target": "steward",
-                        "operation": "task_completed",
-                        "payload": payload,
-                        "message_id": "msg-1",
-                        "payload_hash": hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest(),
-                    }
-                ]
-            )
+            json.dumps([inbound])
         )
 
         # read_outbox reads from nadi_inbox.json (inbound messages)
@@ -274,19 +315,17 @@ class TestNadiFederationTransport:
     def test_read_outbox_quarantines_malformed_items(self, tmp_path):
         transport = NadiFederationTransport(str(tmp_path))
         inbox_path = tmp_path / "nadi_inbox.json"
-        heartbeat_payload = {}
+        heartbeat = {
+            "source": "agent-city",
+            "operation": "heartbeat",
+            "payload": {},
+            "message_id": "msg-1",
+        }
+        heartbeat["payload_hash"] = hashlib.sha256(json.dumps(heartbeat, sort_keys=True).encode()).hexdigest()
         inbox_path.write_text(
             json.dumps(
                 [
-                    {
-                        "source": "agent-city",
-                        "operation": "heartbeat",
-                        "payload": heartbeat_payload,
-                        "message_id": "msg-1",
-                        "payload_hash": hashlib.sha256(
-                            json.dumps(heartbeat_payload, sort_keys=True).encode()
-                        ).hexdigest(),
-                    },
+                    heartbeat,
                     {"source": "agent-city", "payload": {}},
                     "not-a-dict",
                 ]


### PR DESCRIPTION
## Summary

- route federation inbox messages through the canonical transport + gateway path only
- validate whole-message hashes, including the documented hub-added `id` compatibility case
- process signed bootstrap claims before protected messages regardless of hub ordering
- enforce claim proof-of-possession and source/node binding
- consume every gateway-terminal inbox message after acceptance or quarantine
- align replay protection with the 2-hour federation TTL and 15-minute relay cadence

## Production evidence

- Agent City T0c production run: `29308167287`
- canonical Agent City identity: `ag_b670dc6cbcb705fe`
- Steward reproduction run: `29308716184`
- pinned Steward inbox blob: `84be272ee3f952d99c563d0fdfb981bd5d0df0a2` (638 messages)
- reproduction: 7 `Path` NameErrors, 0 gateway markers

Isolated decision run against that exact blob after this patch:

- 638 before
- 616 expired messages left untouched
- 22 live terminal messages evaluated
- 11 accepted: 4 `city_report`, 7 signed claims
- 11 quarantined: 4 missing claim proofs, 4 invalid signatures, 3 unknown senders
- 22 removed from the isolated inbox after terminal judgment
- all four valid T0c reports accepted

## Mutation proof

Before implementation, the new focused tests failed because:

- canonical whole-message hashes with a hub-added `id` were rejected
- Dharma directly ingested claims before the gateway
- a protected message preceding its claim was rejected as unknown
- valid 15-minute-delayed traffic failed the 5-minute replay window
- unsigned bootstrap claims were accepted
- accepted messages remained on disk for the next process

After implementation:

- mutation regressions: 5 passed
- federation transport/gateway/bridge group: 157 passed
- federation + quarantine + relay group: 184 passed
- focused Ruff: passed

## Known baseline

The full suite still stops during collection at the pre-existing error:

`FindingKind.PEER_PROTOCOL_VIOLATION` is referenced but absent.

This is the same live-main baseline documented before this ticket and is unrelated to the eight changed files.

## Safety

- no production state or workflow files changed
- expired backlog is not purged by this patch
- no registry cleanup is included
- Phase 1 remains read-only
- production verification must require gateway markers, zero `Path` crash, accepted T0c reports, and terminal-message removal
