### PR TITLE
fix: persist federation relay deduplication

### DIFF
--- a/steward/federation_relay.py
+++ b/steward/federation_relay.py
@@ -35,6 +35,7 @@ DEFAULT_HUB_REPO = "kimeisele/steward-federation"
 GITHUB_API = "https://api.github.com"
 MIN_RELAY_INTERVAL_S = 60
 NADI_BUFFER_SIZE = 144
+MAX_SEEN_IDS = 4096
 
 
 class DeliveryReceipt:
@@ -98,6 +99,7 @@ class GitHubFederationRelay:
         self._hub_repo = hub_repo
         self._local_outbox = local_outbox or Path("data/federation/nadi_outbox.json")
         self._local_inbox = local_inbox or Path("data/federation/nadi_inbox.json")
+        self._seen_ids_path = self._local_inbox.with_name("relay_seen_ids.json")
         self._reaper = reaper
         self._token = self._load_token()
         self._last_pull: float = 0.0
@@ -105,7 +107,7 @@ class GitHubFederationRelay:
         self._pull_count: int = 0
         self._push_count: int = 0
         self._errors: int = 0
-        self._seen_ids: set[str] = set()  # UUID dedup
+        self._seen_ids = self._load_seen_ids()
         self._pending_receipts: list[DeliveryReceipt] = []  # unconfirmed deliveries
 
     @property
@@ -224,12 +226,13 @@ class GitHubFederationRelay:
         local = self._read_local_inbox()
         existing_keys = {(m.get("source", ""), m.get("timestamp", 0)) for m in local}
 
+        seen_ids_before_pull = set(self._seen_ids)
         for m in all_messages:
             msg_id = m.get("id", "")
             if msg_id and msg_id in self._seen_ids:
                 continue
             if msg_id:
-                self._seen_ids.add(msg_id)
+                self._seen_ids[msg_id] = None
 
             key = (m.get("source", ""), m.get("timestamp", 0))
             if key in existing_keys:
@@ -249,6 +252,9 @@ class GitHubFederationRelay:
                 if not receipt.confirmed and receipt.target in responding_peers:
                     receipt.confirmed = True
                     logger.debug("RELAY: delivery confirmed for batch %s → %s", receipt.batch_id, receipt.target)
+
+        if set(self._seen_ids) != seen_ids_before_pull:
+            self._write_seen_ids()
 
         self._last_pull = time.monotonic()
         self._pull_count += len(new_msgs)
@@ -403,6 +409,28 @@ class GitHubFederationRelay:
         tmp = self._local_inbox.with_suffix(".tmp")
         tmp.write_text(json.dumps(messages, indent=2))
         tmp.rename(self._local_inbox)
+
+    def _load_seen_ids(self) -> dict[str, None]:
+        if not self._seen_ids_path.exists():
+            return {}
+        try:
+            raw = json.loads(self._seen_ids_path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("RELAY: cannot read persistent seen IDs: %s", exc)
+            return {}
+        if not isinstance(raw, list):
+            logger.warning("RELAY: persistent seen IDs must be a JSON list")
+            return {}
+        valid_ids = [msg_id for msg_id in raw if isinstance(msg_id, str) and msg_id]
+        return dict.fromkeys(valid_ids[-MAX_SEEN_IDS:])
+
+    def _write_seen_ids(self) -> None:
+        while len(self._seen_ids) > MAX_SEEN_IDS:
+            self._seen_ids.pop(next(iter(self._seen_ids)))
+        self._seen_ids_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._seen_ids_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(list(self._seen_ids), indent=2))
+        tmp.rename(self._seen_ids_path)
 
     def pending_receipts(self) -> list[DeliveryReceipt]:
         """Unconfirmed delivery receipts (for escalation by DHARMA phase)."""

--- a/tests/test_federation_relay.py
+++ b/tests/test_federation_relay.py
@@ -141,6 +141,61 @@ class TestPullFromHub:
         assert "heartbeat" in ops
         assert "pr_review_request" in ops
 
+    def test_pull_deduplicates_uuid_across_relay_processes(self, tmp_path):
+        message = {
+            "id": "persistent-message-id",
+            "source": "agent-city",
+            "target": "steward",
+            "timestamp": 200,
+            "operation": "city_report",
+        }
+
+        def build_relay():
+            with patch.dict("os.environ", {"GITHUB_TOKEN": "tok"}):
+                return GitHubFederationRelay(
+                    agent_id="steward",
+                    local_inbox=tmp_path / "inbox.json",
+                )
+
+        first = build_relay()
+        with patch("urllib.request.urlopen", side_effect=OSError("skip mailbox scan")):
+            with patch.object(first, "_get_file", side_effect=[([message], "sha1"), ([], "sha2")]):
+                assert first.pull_from_hub() == 1
+
+        (tmp_path / "inbox.json").write_text("[]")
+        second = build_relay()
+        with patch("urllib.request.urlopen", side_effect=OSError("skip mailbox scan")):
+            with patch.object(second, "_get_file", side_effect=[([message], "sha1"), ([], "sha2")]):
+                assert second.pull_from_hub() == 0
+
+        assert json.loads((tmp_path / "relay_seen_ids.json").read_text()) == ["persistent-message-id"]
+
+    def test_pull_recovers_from_corrupt_persistent_seen_ids(self, tmp_path):
+        (tmp_path / "relay_seen_ids.json").write_text("not-json")
+        message = {
+            "id": "message-after-corruption",
+            "source": "agent-city",
+            "target": "steward",
+            "timestamp": 201,
+        }
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "tok"}):
+            relay = GitHubFederationRelay(agent_id="steward", local_inbox=tmp_path / "inbox.json")
+        with patch("urllib.request.urlopen", side_effect=OSError("skip mailbox scan")):
+            with patch.object(relay, "_get_file", side_effect=[([message], "sha1"), ([], "sha2")]):
+                assert relay.pull_from_hub() == 1
+
+        assert json.loads((tmp_path / "relay_seen_ids.json").read_text()) == ["message-after-corruption"]
+
+    def test_persistent_seen_ids_are_bounded(self, tmp_path):
+        from steward.federation_relay import MAX_SEEN_IDS
+
+        stored_ids = [f"message-{index}" for index in range(MAX_SEEN_IDS + 1)]
+        (tmp_path / "relay_seen_ids.json").write_text(json.dumps(stored_ids))
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "tok"}):
+            relay = GitHubFederationRelay(agent_id="steward", local_inbox=tmp_path / "inbox.json")
+
+        assert list(relay._seen_ids) == stored_ids[-MAX_SEEN_IDS:]
+
 
 class TestPushToHub:
     def test_no_token_returns_zero(self):


### PR DESCRIPTION
## Problem
The relay kept seen message UUIDs only in process memory. After the Gateway removed terminal messages from the local inbox, a later heartbeat process could import the same unchanged hub messages again.

## Fix
- persist a bounded 4096-entry UUID window beside the local inbox
- load it on relay startup and update it atomically after durable inbox handling
- recover safely from missing or malformed state
- prove deduplication across two relay instances after simulated Gateway removal

## Validation
- federation/transport/gateway/quarantine/relay suite: 187 passed before final live-head rebase; re-run on rebased head exited 0
- relay suite: 23 passed
- Ruff on changed files: passed
- full-suite baseline remains blocked during collection by pre-existing missing FindingKind.PEER_PROTOCOL_VIOLATION (same failure as base/PR #409)

## Production verification plan
The first post-merge process bootstraps relay_seen_ids.json. A second distinct heartbeat process must then prove unchanged hub UUIDs are not re-imported.