### PR TITLE
fix: make git canonical for heartbeat state

### DIFF
--- a/.github/workflows/steward-heartbeat.yml
+++ b/.github/workflows/steward-heartbeat.yml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.FEDERATION_PAT }}
+          ref: main
+          fetch-depth: 0
 
       - name: Checkout steward-protocol
         uses: actions/checkout@v4
@@ -46,18 +48,6 @@ jobs:
         run: |
           pip install -e .deps/steward-protocol
           pip install -e ".[dev]"
-
-      - name: Restore state
-        uses: actions/cache@v4
-        with:
-          path: |
-            .steward/
-            data/federation/
-          # v2 generation — invalidates pre-TICKET-008 caches that contained the
-          # ghost ag_e3331b8d3b0d20a7 entry. See issue forensics for context.
-          key: steward-state-v3-main
-          restore-keys: |
-            steward-state-v3-
 
       - name: Run autonomous cycle
         env:
@@ -103,19 +93,11 @@ jobs:
           # NEVER use -f here. The previous `git add -f` overrode .gitignore
           # and re-leaked data/federation/.node_keys.json (the steward private
           # key) on every cycle, undoing the TICKET-006 history purge.
-          git add .steward/ data/federation/ || true
-          git diff --cached --quiet || {
+          git add -u -- .steward/ data/federation/
+          git add -- data/federation/
+          if ! git diff --cached --quiet; then
             git commit -m "chore: heartbeat #${{ github.run_number }} state sync"
-            git pull --rebase origin main --autostash || git reset --hard origin/main
+            git pull --rebase origin main
             git remote set-url origin https://x-access-token:${{ secrets.FEDERATION_PAT }}@github.com/kimeisele/steward.git
-            git push || true
-          }
-
-      - name: Save state
-        if: always()
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            .steward/
-            data/federation/
-          key: steward-state-v3-main
+            git push
+          fi


### PR DESCRIPTION
## Root cause
`actions/cache` restores `.steward/` and `data/federation/` from the immutable key `steward-state-v3-main`. That cache was created on 2026-07-12 and every later save is rejected because the key already exists. Each heartbeat therefore overwrites freshly committed registry, inbox, quarantine, and relay dedup state with the stale snapshot.

A queued heartbeat also checks out the trigger SHA rather than the latest `main`. If another heartbeat commits before the queued job starts, the current rebase fallback resets to `origin/main`, leaves a detached HEAD, discards the new state, and `git push || true` still reports a green workflow. Production run 29310913347 demonstrated that exact sequence.

## Fix
- explicitly check out current `main` with full history at execution time
- remove cache restore/save; tracked Git state is the single source of truth
- stage tracked `.steward` state and non-ignored federation state without forcing ignored private keys
- fail visibly on rebase or push failure instead of resetting/discarding state

## Validation
- YAML parses successfully
- commit-step shell passes `bash -n`
- static invariants verify no Restore/Save cache steps, no reset fallback, and no swallowed push failure
- both scoped staging commands were dry-run successfully
- rebased onto exact live base `d97503c6f27996051c0b1203ae50578cdcf034a6`

## Production acceptance
1. delete the obsolete Actions cache after merge
2. run one heartbeat and verify no cache restore/save steps and a successful state push
3. run a second distinct heartbeat and verify the four known T0c report UUIDs are not processed again and the canonical registry entry remains present