### PR TITLE
fix: autostash heartbeat runtime changes

### DIFF
--- a/.github/workflows/steward-heartbeat.yml
+++ b/.github/workflows/steward-heartbeat.yml
@@ -97,7 +97,7 @@ jobs:
           git add -- data/federation/
           if ! git diff --cached --quiet; then
             git commit -m "chore: heartbeat #${{ github.run_number }} state sync"
-            git pull --rebase origin main
+            git pull --rebase --autostash origin main
             git remote set-url origin https://x-access-token:${{ secrets.FEDERATION_PAT }}@github.com/kimeisele/steward.git
             git push
           fi


### PR DESCRIPTION
Production run `29311896422` proved the cache-removal workflow is active and errors are no longer masked. Its state commit was created successfully, but `git pull --rebase` then failed because editable dependency installation leaves unrelated tracked runtime changes unstaged.

This focused follow-up restores `--autostash` for those runtime changes while retaining every fail-closed property from #416:
- no stale state cache
- no `reset --hard` fallback
- no swallowed push failure
- explicit current-main checkout

Validation: YAML parse passed, extracted shell passed `bash -n`, and static assertions confirm no reset or `push || true`.