### PR TITLE
fix: restore protocol violation diagnostics

### DIFF
--- a/steward/federation_gateway.py
+++ b/steward/federation_gateway.py
@@ -500,9 +500,7 @@ class FederationGateway(GatewayProtocol):
         messages = sorted(
             messages,
             key=lambda message: (
-                0
-                if isinstance(message, dict) and message.get("operation") == "federation.agent_claim"
-                else 1
+                0 if isinstance(message, dict) and message.get("operation") == "federation.agent_claim" else 1
             ),
         )
 

--- a/steward/healer/types.py
+++ b/steward/healer/types.py
@@ -38,7 +38,7 @@ _STRATEGY: dict[FindingKind, FixStrategy] = {
     FindingKind.CIRCULAR_IMPORT: FixStrategy.DETERMINISTIC,
     FindingKind.CI_FAILING: FixStrategy.COMPOUND,
     FindingKind.NADI_BLOCKED: FixStrategy.DETERMINISTIC,
-    FindingKind.PEER_PROTOCOL_VIOLATION: FixStrategy.DETERMINISTIC,
+    FindingKind.PEER_PROTOCOL_VIOLATION: FixStrategy.SKIP,
     FindingKind.BASE_EXCEPTION_CATCH: FixStrategy.DETERMINISTIC,
     FindingKind.DYNAMIC_IMPORT: FixStrategy.DETERMINISTIC,
     FindingKind.UNBOUNDED_COLLECTION: FixStrategy.SKIP,  # needs human decision on size

--- a/steward/hooks/dharma.py
+++ b/steward/hooks/dharma.py
@@ -550,12 +550,12 @@ class DharmaFederationHook(BasePhaseHook):
 
         if rejected and transport is not None:
             try:
-                transport.quarantine_messages(rejected, reason='inbox_validation_failed', stage='dharma')
+                transport.quarantine_messages(rejected, reason="inbox_validation_failed", stage="dharma")
                 removed = transport.remove_inbox_messages(rejected)
                 logger.info(
-                    'FEDERATION: quarantined %d rejected message(s), removed %d from inbox',
+                    "FEDERATION: quarantined %d rejected message(s), removed %d from inbox",
                     len(rejected),
                     removed,
                 )
             except Exception as e:
-                logger.error('FEDERATION: could not quarantine rejected messages: %s', e)
+                logger.error("FEDERATION: could not quarantine rejected messages: %s", e)

--- a/steward/senses/diagnostic_sense.py
+++ b/steward/senses/diagnostic_sense.py
@@ -57,6 +57,7 @@ class FindingKind(enum.Enum):
     LARGE_FILE = "large_file"
     CIRCULAR_IMPORT = "circular_import"
     NADI_BLOCKED = "nadi_blocked"
+    PEER_PROTOCOL_VIOLATION = "peer_protocol_violation"
     BASE_EXCEPTION_CATCH = "base_exception_catch"
     DYNAMIC_IMPORT = "dynamic_import"
     UNBOUNDED_COLLECTION = "unbounded_collection"
@@ -716,7 +717,6 @@ def _analyze_federation(repo_path: Path) -> tuple[list[Finding], bool, dict, boo
         except OSError:
             pass
 
-
     # A peer whose messages keep getting refused is not flaky — it is speaking the
     # wrong protocol (its own emit() with no signature, the way agent-city did).
     # dharma already refuses those and records who; read that here so it becomes a
@@ -730,12 +730,13 @@ def _analyze_federation(repo_path: Path) -> tuple[list[Finding], bool, dict, boo
             _peers = {}
         for _peer_id, _count in sorted(_peers.items(), key=lambda kv: -kv[1]):
             findings.append(
-                _finding(
-                    FindingKind.PEER_PROTOCOL_VIOLATION,
-                    Severity.WARNING,
-                    f"peer {_peer_id} sent {_count} unsigned or malformed message(s): its"
+                Finding(
+                    kind=FindingKind.PEER_PROTOCOL_VIOLATION,
+                    severity=Severity.WARNING,
+                    file="data/federation/protocol_violations.json",
+                    detail=f"peer {_peer_id} sent {_count} unsigned or malformed message(s): its"
                     f" messages carry no signature, so nothing it says can be verified",
-                    f"switch {_peer_id} to nadi_kit — pull nadi_kit.py, pass"
+                    fix_hint=f"switch {_peer_id} to nadi_kit — pull nadi_kit.py, pass"
                     f" NODE_PRIVATE_KEY, let it write the outbox (see agent-world)",
                 )
             )

--- a/tests/test_diagnostic_sense.py
+++ b/tests/test_diagnostic_sense.py
@@ -332,6 +332,21 @@ class TestFederationAnalysis:
         assert "code_analysis" in caps
         assert "ci_automation" in caps
 
+    def test_protocol_violations_become_actionable_findings(self, tmp_path):
+        federation = tmp_path / "data" / "federation"
+        federation.mkdir(parents=True)
+        (federation / "protocol_violations.json").write_text(
+            json.dumps({"observed_at": 123.0, "peers": {"ag_malformed": 4}})
+        )
+
+        findings, _, _, _, _ = _analyze_federation(tmp_path)
+
+        violation = next(finding for finding in findings if finding.kind.value == "peer_protocol_violation")
+        assert violation.severity == Severity.WARNING
+        assert violation.file == "data/federation/protocol_violations.json"
+        assert "ag_malformed" in violation.detail
+        assert "nadi_kit" in violation.fix_hint
+
 
 # ── Full Diagnostic ──────────────────────────────────────────────────
 

--- a/tests/test_federation_gateway.py
+++ b/tests/test_federation_gateway.py
@@ -841,9 +841,7 @@ class TestProcessInbound:
         registry = json.loads((tmp_path / "verified_agents.json").read_text())
         assert registry[node_keys.node_id]["public_key"] == node_keys.public_key
         assert reaper.get_peer("agent-city") is not None
-        quarantine_records = [
-            path for path in (tmp_path / "quarantine").glob("*.json") if path.name != "index.json"
-        ]
+        quarantine_records = [path for path in (tmp_path / "quarantine").glob("*.json") if path.name != "index.json"]
         assert quarantine_records == []
 
     def test_spoofed_agent_claim_is_quarantined_for_identity_spoofing(self, tmp_path):

--- a/tests/test_federation_transport.py
+++ b/tests/test_federation_transport.py
@@ -302,9 +302,7 @@ class TestNadiFederationTransport:
             "message_id": "msg-1",
         }
         inbound["payload_hash"] = hashlib.sha256(json.dumps(inbound, sort_keys=True).encode()).hexdigest()
-        inbox_path.write_text(
-            json.dumps([inbound])
-        )
+        inbox_path.write_text(json.dumps([inbound]))
 
         # read_outbox reads from nadi_inbox.json (inbound messages)
         messages = transport.read_outbox()

--- a/tests/test_healer_fixers.py
+++ b/tests/test_healer_fixers.py
@@ -40,28 +40,16 @@ class _F:
 
 class TestFixerRegistry:
     def test_all_deterministic_kinds_have_fixers(self):
-        for kind, strategy in [
-            (FindingKind.UNDECLARED_DEPENDENCY, FixStrategy.DETERMINISTIC),
-            (FindingKind.MISSING_DEPENDENCY, FixStrategy.DETERMINISTIC),
-            (FindingKind.NO_FEDERATION_DESCRIPTOR, FixStrategy.DETERMINISTIC),
-            (FindingKind.NO_PEER_JSON, FixStrategy.DETERMINISTIC),
-            (FindingKind.NO_CI, FixStrategy.DETERMINISTIC),
-            (FindingKind.NO_TESTS, FixStrategy.DETERMINISTIC),
-            (FindingKind.BROKEN_IMPORT, FixStrategy.DETERMINISTIC),
-            (FindingKind.SYNTAX_ERROR, FixStrategy.DETERMINISTIC),
-            (FindingKind.CIRCULAR_IMPORT, FixStrategy.DETERMINISTIC),
-            (FindingKind.NADI_BLOCKED, FixStrategy.DETERMINISTIC),
-            (FindingKind.BASE_EXCEPTION_CATCH, FixStrategy.DETERMINISTIC),
-            (FindingKind.DYNAMIC_IMPORT, FixStrategy.DETERMINISTIC),
-        ]:
-            assert classify(kind) == strategy, f"{kind} should be {strategy}"
-            assert kind in _FIXERS, f"{kind} has no registered fixer"
+        for kind in FindingKind:
+            if classify(kind) == FixStrategy.DETERMINISTIC:
+                assert kind in _FIXERS, f"{kind} has no registered fixer"
 
     def test_compound_classified(self):
         assert classify(FindingKind.CI_FAILING) == FixStrategy.COMPOUND
 
     def test_skip_classified(self):
         assert classify(FindingKind.LARGE_FILE) == FixStrategy.SKIP
+        assert classify(FindingKind.PEER_PROTOCOL_VIOLATION) == FixStrategy.SKIP
 
     def test_import_to_pip_mappings(self):
         assert _IMPORT_TO_PIP["yaml"] == "pyyaml"


### PR DESCRIPTION
## Root cause
Commit `20f04b3f5c` introduced the protocol-violation diagnostic path incompletely:

- `FindingKind.PEER_PROTOCOL_VIOLATION` was referenced by the healer but never added to the enum, so test collection and production KARMA imports raised `AttributeError`.
- `_analyze_federation()` called a nonexistent `_finding` helper, so Ruff reported F821 and a real violation file raised `NameError`.
- the kind was classified as deterministic although no deterministic fixer exists, causing the healer to count it as fixable and silently skip it.

## Minimal fix
- add the missing enum member
- construct the existing `Finding` dataclass directly with the violation-state file attached
- classify the cross-repo remediation as `SKIP` until a real, tested fixer exists
- make the registry test dynamically require a registered fixer for every deterministic kind
- add a regression test that reads a real `protocol_violations.json` shape

No new abstraction and no speculative cross-repo autofixer.

## Red proof
Before implementation:
- diagnostic regression failed with `NameError: _finding is not defined`
- healer regression could not collect with missing `PEER_PROTOCOL_VIOLATION`

## Validation
- targeted new regressions: 3 passed
- diagnostic/healer group: 171 passed
- full Ruff (`steward/ tests/`): passed
- full suite: **2120 passed, 13 skipped**, exit 0, in 1014.31s
- rebased follow-up gates: 171 passed; full Ruff passed

The only commits arriving during the final rebase changed runtime state and `CLAUDE.md`, not Steward Python code.