### PR TITLE
docs: record slice C integration evidence

### DIFF
--- a/docs/PHASE2_BEFUND.md
+++ b/docs/PHASE2_BEFUND.md
@@ -2138,3 +2138,19 @@ werden und bleibt seinerseits bis zur exakt gebundenen Operatorfreigabe ungemerg
 
 Der historische G2-Befund bleibt erhalten und erhält eine explizite superseding note.
 Phase 1 bleibt read-only. PHASE2_CURRENT bleibt ein widerlegbarer Arbeitsstand, keine SSOT.
+
+## 20. Slice-C-CI korrigiert den zulässigen Integrationstest-Scope
+
+Der erste vollständige CI-Lauf des exakten Slice-C-Kandidaten war in Lint und Security
+grün und scheiterte in Python 3.11/3.12 am selben alten Integrationstest:
+`TestGenerateBriefing.test_includes_orientation_from_conventions` verlangte weiterhin
+`Antahkarana` oder `cognitive` aus der realen `.steward/conventions.md`.
+
+Das ist kein Source- oder Parserfehler. Slice-C-G2 entschied ausdrücklich, dass die erste
+versionierte Orientation leer bleibt und alte Architekturprosa default-deny entfernt
+wird. Den C0-Vertrag zur Befriedigung des alten Tests aufzuweichen wäre falsch.
+
+Der erlaubte Source-PR-Scope wird daher exakt um `tests/test_briefing.py` erweitert. Dort
+darf nur der obsolete Real-Repo-Test zu einem Integrationsbeweis geändert werden, dass der
+Legacy-Preview eine leere versionierte Orientation toleriert und keine Root-Datei schreibt.
+Produktcode, zusätzliche Orientation-Prosa und jeder weitere Pfad bleiben verboten.

--- a/docs/PHASE2_CURRENT.md
+++ b/docs/PHASE2_CURRENT.md
@@ -237,8 +237,11 @@ Der Vertrag trennt:
 - die explizite Chat-/CLI-Freigabe als prozeduralen `single_owner_hitl`-Beleg.
 
 Liegt das Amendment regulär auf `main`, ist der nächste isolierte Auftrag Slice C: exakt
-`.steward/conventions.md` und `tests/test_context_constitution.py` in einem **separaten**
-Source-/Test-PR. Dieser PR wird auf finalem Head eingefroren und erst nach einem Reviewpaket
+`.steward/conventions.md`, `tests/test_context_constitution.py` und die notwendige
+Integrationstestkorrektur in `tests/test_briefing.py` in einem **separaten** Source-/Test-
+PR. Der erste vollständige CI-Lauf bewies, dass der alte Real-Repo-Test fälschlich die
+bewusst entfernte `Antahkarana`-/`cognitive`-Orientation voraussetzt. Der Source-PR wird auf
+finalem Head eingefroren und erst nach einem Reviewpaket
 sowie der exakten Operatorfreigabe
 `APPROVE CONSTITUTION <head_sha> <source_blob> <c0_sha256>` gemergt. Jeder weitere Commit
 verwirft die Freigabe.

--- a/specs/context_bridge_evidence/FEATURE_01_SLICE_C_G2_PREFLIGHT.md
+++ b/specs/context_bridge_evidence/FEATURE_01_SLICE_C_G2_PREFLIGHT.md
@@ -162,10 +162,17 @@ Erlaubt wären ausschließlich:
 ```text
 .steward/conventions.md
 tests/test_context_constitution.py
+tests/test_briefing.py
 ```
 
 `tests/test_context_constitution.py` ist neu. Es liest ausschließlich die echte Source und
 die normative Feature-00-Spec. Es dupliziert den C0-Wortlaut nicht.
+
+`tests/test_briefing.py` erhält ausschließlich die notwendige Korrektur seines bestehenden
+Real-Repo-Integrationstests: Eine leere versionierte Orientation ist nach diesem G2 ein
+gültiger Zustand und darf nicht weiter durch die alten Begriffe `Antahkarana` oder
+`cognitive` widerlegt werden. Der Test muss stattdessen beweisen, dass der Legacy-Preview
+mit der leeren Orientation weiterhin erfolgreich und ohne Root-Write erzeugt wird.
 
 Jeder weitere Pfad stoppt den Source-PR. Insbesondere verboten:
 
@@ -201,9 +208,22 @@ Der grüne Vertrag prüft mindestens:
    `write CLAUDE.md` fehlen.
 8. CR, BOM, NUL, bidi/zero-width, doppelter oder verschachtelter Marker blockieren.
 9. `CLAUDE.md` bleibt exakt der Base-Blob; `AGENTS.md` bleibt absent.
-10. Der PR-Diff enthält nur die zwei erlaubten Pfade.
+10. Der PR-Diff enthält nur die drei erlaubten Pfade.
+11. Der reale Legacy-Preview toleriert die leere versionierte Orientation, ohne eine
+    Architekturphrase aus der entfernten Source zu verlangen oder Root-Dateien zu ändern.
 
 Punkte 9 und 10 sind PR-/Git-Contract-Prüfungen, keine bloßen Unit-Assertions.
+
+### 6.1 Nachträglicher Integrationsbeweis
+
+Der erste vollständige PR-CI-Lauf auf dem exakten Zwei-Pfad-Kandidaten scheiterte in
+Python 3.11 und 3.12 ausschließlich an
+`TestGenerateBriefing.test_includes_orientation_from_conventions`. Der Test behauptete,
+die reale Source müsse weiterhin `Antahkarana` oder `cognitive` enthalten. Diese Annahme
+widerspricht der bereits geschlossenen Entscheidung für eine leere erste Orientation.
+
+Der neue Befund erweitert den zulässigen Scope genau um diesen vorhandenen Test. Er
+autorisiert weder eine Produktänderung noch zusätzliche Orientation-Prosa.
 
 ## 7. Review- und Attestation-Gate
 


### PR DESCRIPTION
## Scope

Evidence and Phase-2 continuity only. No source, test, product, root, workflow, setting, or runtime-state change.

## New evidence

The exact two-path Slice-C candidate passed targeted tests but full Python 3.11 and 3.12 CI both stopped on the same legacy real-repository briefing test. That test still required architecture words which Slice-C G2 deliberately removes by choosing an empty first orientation.

This correction expands the later Source PR by exactly one existing test path, `tests/test_briefing.py`, solely to replace that obsolete assumption with successful empty-orientation preview behavior. It does not authorize product changes or additional orientation prose.
