### PR TITLE
fix: parse structured briefing orientation

### DIFF
--- a/steward/briefing_stages.py
+++ b/steward/briefing_stages.py
@@ -37,6 +37,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
 
+from steward.context_contract import ContractViolation, parse_conventions
+
 logger = logging.getLogger("STEWARD.BRIEFING_STAGES")
 
 # ── Token Budget Constants ─────────────────────────────────────────
@@ -905,22 +907,36 @@ def _load_orientation(cwd: str) -> str:
     if not path.is_file():
         return ""
     try:
-        content = path.read_text(encoding="utf-8").strip()
-        lines = content.splitlines()
-        start = 0
-        for i, line in enumerate(lines):
-            stripped = line.strip()
-            if stripped and not stripped.startswith("#"):
-                start = i
-                if i > 0 and lines[i - 1].strip().startswith("# "):
-                    start = i - 1
-                break
-            if stripped.startswith("## "):
-                start = i
-                break
-        return "\n".join(lines[start:]).strip()
+        source = path.read_bytes()
     except OSError:
         return ""
+    if not source:
+        return ""
+    if b"<!-- steward-context:" in source:
+        try:
+            parsed = parse_conventions(source)
+        except ContractViolation as exc:
+            logger.warning("Structured conventions rejected: %s", exc.code)
+            return ""
+        return (parsed.orientation or "").strip()
+    try:
+        content = source.decode("utf-8").strip()
+    except UnicodeDecodeError:
+        logger.warning("Legacy conventions rejected: invalid_utf8")
+        return ""
+    lines = content.splitlines()
+    start = 0
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            start = i
+            if i > 0 and lines[i - 1].strip().startswith("# "):
+                start = i - 1
+            break
+        if stripped.startswith("## "):
+            start = i
+            break
+    return "\n".join(lines[start:]).strip()
 
 
 def _collect_annotations(high_priority_only: bool = False) -> str:

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -9,6 +9,14 @@ from steward.briefing import (
     generate_briefing,
     write_claude_md,
 )
+from steward.context_contract import C0_BEGIN, C0_END, ORIENTATION_BEGIN, ORIENTATION_END
+
+
+def structured_conventions(orientation: str = "## Architecture Map\nOnly orientation.\n") -> bytes:
+    return (
+        f"{C0_BEGIN}\n## Private Constitution\nNever orientation.\n{C0_END}\n\n"
+        f"{ORIENTATION_BEGIN}\n{orientation.rstrip(chr(10))}\n{ORIENTATION_END}\n"
+    ).encode("utf-8")
 
 
 class TestGenerateBriefing:
@@ -105,6 +113,45 @@ class TestLoadOrientation:
         steward_dir = tmp_path / ".steward"
         steward_dir.mkdir()
         (steward_dir / "conventions.md").write_text("")
+        assert _load_orientation(str(tmp_path)) == ""
+
+    def test_versioned_source_returns_only_orientation(self, tmp_path):
+        steward_dir = tmp_path / ".steward"
+        steward_dir.mkdir()
+        (steward_dir / "conventions.md").write_bytes(structured_conventions())
+
+        result = _load_orientation(str(tmp_path))
+
+        assert result == "## Architecture Map\nOnly orientation."
+        assert "Private Constitution" not in result
+        assert "steward-context:" not in result
+
+    def test_versioned_empty_orientation_returns_empty(self, tmp_path):
+        steward_dir = tmp_path / ".steward"
+        steward_dir.mkdir()
+        (steward_dir / "conventions.md").write_bytes(structured_conventions(orientation=""))
+
+        assert _load_orientation(str(tmp_path)) == ""
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            structured_conventions().replace(C0_END.encode(), b""),
+            structured_conventions() + b"<!-- steward-context:unknown:v1:begin -->\n",
+        ],
+    )
+    def test_malformed_marker_source_fails_closed(self, tmp_path, source):
+        steward_dir = tmp_path / ".steward"
+        steward_dir.mkdir()
+        (steward_dir / "conventions.md").write_bytes(source)
+
+        assert _load_orientation(str(tmp_path)) == ""
+
+    def test_invalid_utf8_fails_closed(self, tmp_path):
+        steward_dir = tmp_path / ".steward"
+        steward_dir.mkdir()
+        (steward_dir / "conventions.md").write_bytes(b"\xff")
+
         assert _load_orientation(str(tmp_path)) == ""
 
 


### PR DESCRIPTION
## Scope

Exactly two paths:

- `steward/briefing_stages.py`
- `tests/test_briefing.py`

No Constitution source, root context file, writer, workflow, setting, runtime state, or delivery change.

## Contract

- versioned sources are parsed by the existing strict `parse_conventions()`
- only the orientation payload reaches `OrientationStage`; C0 and markers cannot leak into it
- valid empty orientation returns empty
- malformed structured input and invalid UTF-8 fail closed without logging raw source
- unmarked legacy conventions retain the existing temporary behavior until Slice C lands
- tests call `_load_orientation()` directly and cannot be hidden by the pipeline stage exception boundary

## Validation

- red first: 5 contract failures, including C0 leakage and invalid UTF-8
- final direct loader tests: 9 passed
- adjacent briefing/context tests: 102 passed
- Ruff check and format check pass
- `git diff --check`

PR #552 remains draft and blocked until this prerequisite is merged.
