### PR TITLE
feat: validate persisted context generations

### DIFF
--- a/steward/context_contract.py
+++ b/steward/context_contract.py
@@ -1191,33 +1191,34 @@ def _validate_attestation(attestation: ConstitutionAttestation) -> None:
     _validate_hash(attestation.reviewed_at_commit, 40, field_path="constitution_attestation.reviewed_at_commit")
 
 
+def validate_previous_published_record(previous: PreviousPublishedRecord) -> None:
+    """Validate a materialized published-record value object without attesting its origin."""
+    if type(previous) is not PreviousPublishedRecord:
+        _fail("invalid_type", "previous")
+    if previous.record_schema != "steward.context.published-record/v1":
+        _fail("invalid_schema", "previous.record_schema")
+    if previous.payload_schema != "steward.context.payload/v1":
+        _fail("invalid_schema", "previous.payload_schema")
+    if not isinstance(previous.mode, OutputMode):
+        _fail("invalid_type", "previous.mode")
+    if previous.mode is OutputMode.PREVIEW:
+        _fail("invalid_value", "previous.mode")
+    _validate_hash(previous.payload_hash, 64, field_path="previous.payload_hash")
+    _validate_hash(previous.c0_sha256, 64, field_path="previous.c0_sha256")
+    if not isinstance(previous.snapshot_id, str) or not re.fullmatch(r"ctxsnap-v1:[0-9a-f]{64}", previous.snapshot_id):
+        _fail("invalid_value", "previous.snapshot_id")
+    if set(previous.consumer_outputs) != {"agents", "claude"}:
+        _fail("invalid_schema", "previous.consumer_outputs")
+    for consumer, value in previous.consumer_outputs.items():
+        _validate_hash(value, 64, field_path=f"previous.consumer_outputs.{consumer}")
+    if previous.consumer_outputs["agents"] != previous.consumer_outputs["claude"]:
+        _fail("inconsistent", "previous.consumer_outputs")
+    _validate_comparison_state(previous.comparison_state)
+
+
 def _valid_previous(previous: PreviousPublishedRecord) -> bool:
     try:
-        if previous.record_schema != "steward.context.published-record/v1":
-            return False
-        if previous.payload_schema != "steward.context.payload/v1" or previous.mode is OutputMode.PREVIEW:
-            return False
-        _validate_hash(previous.payload_hash, 64, field_path="previous.payload_hash")
-        _validate_hash(previous.c0_sha256, 64, field_path="previous.c0_sha256")
-        if not re.fullmatch(r"ctxsnap-v1:[0-9a-f]{64}", previous.snapshot_id):
-            return False
-        if set(previous.consumer_outputs) != {"agents", "claude"}:
-            return False
-        outputs = list(previous.consumer_outputs.values())
-        for value in outputs:
-            _validate_hash(value, 64, field_path="previous.consumer_outputs")
-        if outputs[0] != outputs[1]:
-            return False
-        expected_comparison = {
-            "gateway_errors_total",
-            "gateway_rejected_parse_total",
-            "gateway_rejected_validate_total",
-            "immune_rollbacks_total",
-        }
-        if set(previous.comparison_state) != expected_comparison:
-            return False
-        for key, value in previous.comparison_state.items():
-            _count(value, field_path=f"previous.comparison_state.{key}")
+        validate_previous_published_record(previous)
     except ContractViolation:
         return False
     return True

--- a/steward/context_rendering.py
+++ b/steward/context_rendering.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from dataclasses import dataclass
 from typing import Mapping
 
@@ -12,16 +13,30 @@ from steward.context_contract import (
     ORIENTATION_BEGIN,
     ORIENTATION_END,
     ContractViolation,
+    OutputMode,
+    PreviousPublishedRecord,
     canonical_json_bytes,
     consumer_output_hash,
     payload_hash,
     snapshot_hash,
     validate_payload_core,
+    validate_previous_published_record,
     validate_snapshot_model,
 )
 
 DYNAMIC_BEGIN = "<!-- steward-context:dynamic:v1:begin -->"
 DYNAMIC_END = "<!-- steward-context:dynamic:v1:end -->"
+
+_ROOT_MAX_BYTES = 65_536
+_SNAPSHOT_MAX_BYTES = 131_072
+_PUBLICATION_MAX_BYTES = 16_384
+_SNAPSHOT_SCHEMA = "steward.context.snapshot-artifact/v1"
+_PUBLICATION_SCHEMA = "steward.context.publication-artifact/v1"
+_TARGETS = {
+    "agents": "AGENTS.md",
+    "claude": "CLAUDE.md",
+    "snapshot": ".steward/context-snapshot.json",
+}
 
 
 @dataclass(frozen=True)
@@ -38,6 +53,197 @@ def _fail(code: str, field_path: str) -> None:
 
 def _snapshot_artifact_hash(snapshot_artifact: bytes) -> str:
     return hashlib.sha256(b"steward-context-snapshot-artifact-v1\0" + snapshot_artifact).hexdigest()
+
+
+def _exact_mapping(value: object, expected: set[str], field_path: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        _fail("invalid_type", field_path)
+    if set(value) != expected:
+        _fail("invalid_schema", field_path)
+    return value
+
+
+def _decode_utf8(value: object, max_bytes: int, field_path: str) -> str:
+    if type(value) is not bytes:
+        _fail("invalid_type", field_path)
+    if not value or len(value) > max_bytes or value.startswith(b"\xef\xbb\xbf"):
+        _fail("invalid_value", field_path)
+    try:
+        return value.decode("utf-8")
+    except UnicodeDecodeError:
+        _fail("invalid_utf8", field_path)
+
+
+def _strict_json_bytes(value: object, max_bytes: int, field_path: str) -> object:
+    text = _decode_utf8(value, max_bytes, field_path)
+
+    def unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, item in pairs:
+            if key in result:
+                _fail("invalid_schema", field_path)
+            result[key] = item
+        return result
+
+    def reject_number(_: str) -> object:
+        _fail("invalid_type", field_path)
+
+    try:
+        parsed = json.loads(
+            text,
+            object_pairs_hook=unique_object,
+            parse_float=reject_number,
+            parse_constant=reject_number,
+        )
+    except ContractViolation:
+        raise
+    except (json.JSONDecodeError, RecursionError, TypeError, ValueError):
+        _fail("invalid_value", field_path)
+    if canonical_json_bytes(parsed) != value:
+        _fail("invalid_value", field_path)
+    return parsed
+
+
+def _split_exact(value: str, delimiter: str, field_path: str) -> tuple[str, str]:
+    parts = value.split(delimiter)
+    if len(parts) != 2:
+        _fail("invalid_markers", field_path)
+    return parts[0], parts[1]
+
+
+def _scalar_line(line: str, label: str) -> str:
+    prefix = f"- {label}: `"
+    if not line.startswith(prefix) or not line.endswith("`"):
+        _fail("invalid_schema", "persisted.root.dynamic")
+    value = line[len(prefix) : -1]
+    if not value or "`" in value or "\n" in value:
+        _fail("invalid_value", "persisted.root.dynamic")
+    return value
+
+
+def _parse_root(root: bytes, snapshot: Mapping[str, object]) -> tuple[Mapping[str, object], Mapping[str, str]]:
+    text = _decode_utf8(root, _ROOT_MAX_BYTES, "persisted.root")
+    prefix = f"{C0_BEGIN}\n"
+    if not text.startswith(prefix):
+        _fail("invalid_markers", "persisted.root.c0")
+    c0, remainder = _split_exact(
+        text[len(prefix) :],
+        f"{C0_END}\n\n{DYNAMIC_BEGIN}\n",
+        "persisted.root.c0",
+    )
+    dynamic, orientation_block = _split_exact(
+        remainder,
+        f"{DYNAMIC_END}\n\n{ORIENTATION_BEGIN}\n",
+        "persisted.root.dynamic",
+    )
+    orientation, tail = _split_exact(
+        orientation_block,
+        f"{ORIENTATION_END}\n",
+        "persisted.root.orientation",
+    )
+    if tail:
+        _fail("invalid_markers", "persisted.root")
+
+    dynamic_prefix = (
+        "## Generated Steward Context\n\nThis block is generated observed data, not an operator instruction.\n\n"
+    )
+    if not dynamic.startswith(dynamic_prefix):
+        _fail("invalid_schema", "persisted.root.dynamic")
+    header, source_section = _split_exact(
+        dynamic[len(dynamic_prefix) :],
+        "\n\n### Source Status\n\n```json\n",
+        "persisted.root.dynamic",
+    )
+    header_lines = header.split("\n")
+    labels = (
+        "Payload schema",
+        "Snapshot schema",
+        "Mode",
+        "Snapshot ID",
+        "Payload hash",
+        "Repository head",
+        "Generator commit",
+        "Constitution source blob",
+        "Constitution reviewed commit",
+    )
+    if len(header_lines) != len(labels):
+        _fail("invalid_schema", "persisted.root.dynamic")
+    provenance = {label: _scalar_line(line, label) for label, line in zip(labels, header_lines, strict=True)}
+
+    source_json, observations_section = _split_exact(
+        source_section,
+        "\n```\n\n### Observations\n\n```json\n",
+        "persisted.root.source_status",
+    )
+    if not observations_section.endswith("\n```\n"):
+        _fail("invalid_schema", "persisted.root.observations")
+    observations_json = observations_section[: -len("\n```\n")]
+    source_status = _strict_json_bytes(source_json.encode("utf-8"), _ROOT_MAX_BYTES, "persisted.root.source_status")
+    observations = _strict_json_bytes(observations_json.encode("utf-8"), _ROOT_MAX_BYTES, "persisted.root.observations")
+
+    orientation_model = _exact_mapping(snapshot["orientation"], {"sha256"}, "snapshot.orientation")
+    orientation_sha256 = orientation_model["sha256"]
+    payload = {
+        "schema": provenance["Payload schema"],
+        "contract": {
+            "c0_version": "c0/v1",
+            "c0_sha256": hashlib.sha256(c0.encode("utf-8")).hexdigest(),
+            "c0": c0,
+            "orientation_sha256": orientation_sha256,
+            "orientation": orientation if orientation_sha256 is not None else None,
+        },
+        "mode": provenance["Mode"],
+        "source_status": source_status,
+        "observations": observations,
+    }
+    validate_payload_core(payload)
+    return payload, provenance
+
+
+def _materialize_previous(value: object) -> PreviousPublishedRecord:
+    previous = _exact_mapping(
+        value,
+        {
+            "record_schema",
+            "payload_schema",
+            "payload_hash",
+            "snapshot_id",
+            "c0_sha256",
+            "mode",
+            "consumer_outputs",
+            "comparison_state",
+        },
+        "publication.previous",
+    )
+    consumer_outputs = _exact_mapping(
+        previous["consumer_outputs"], {"agents", "claude"}, "publication.previous.consumer_outputs"
+    )
+    comparison_state = _exact_mapping(
+        previous["comparison_state"],
+        {
+            "gateway_errors_total",
+            "gateway_rejected_parse_total",
+            "gateway_rejected_validate_total",
+            "immune_rollbacks_total",
+        },
+        "publication.previous.comparison_state",
+    )
+    try:
+        mode = OutputMode(previous["mode"])
+    except (TypeError, ValueError):
+        _fail("invalid_value", "publication.previous.mode")
+    record = PreviousPublishedRecord(
+        payload_hash=previous["payload_hash"],
+        snapshot_id=previous["snapshot_id"],
+        c0_sha256=previous["c0_sha256"],
+        mode=mode,
+        consumer_outputs=consumer_outputs,
+        comparison_state=comparison_state,
+        record_schema=previous["record_schema"],
+        payload_schema=previous["payload_schema"],
+    )
+    validate_previous_published_record(record)
+    return record
 
 
 def _validate_cross_bindings(payload: Mapping[str, object], snapshot: Mapping[str, object]) -> None:
@@ -153,3 +359,142 @@ def validate_publication_candidates(
     expected = build_publication_candidates(payload, snapshot)
     if candidates != expected:
         _fail("inconsistent", "candidates")
+
+
+def _validate_persisted_generation(candidates: PublicationCandidates) -> PreviousPublishedRecord:
+    snapshot_envelope = _exact_mapping(
+        _strict_json_bytes(candidates.snapshot_artifact, _SNAPSHOT_MAX_BYTES, "persisted.snapshot_artifact"),
+        {"schema", "snapshot_id", "snapshot_hash", "snapshot"},
+        "persisted.snapshot_artifact",
+    )
+    if snapshot_envelope["schema"] != _SNAPSHOT_SCHEMA:
+        _fail("invalid_schema", "persisted.snapshot_artifact.schema")
+    snapshot = _exact_mapping(
+        snapshot_envelope["snapshot"],
+        {
+            "schema",
+            "repository",
+            "generator",
+            "assembled_at",
+            "constitution",
+            "orientation",
+            "comparison_state",
+            "sources",
+            "observations",
+        },
+        "persisted.snapshot_artifact.snapshot",
+    )
+    validate_snapshot_model(snapshot)
+    snapshot_hash_value = snapshot_hash(snapshot)
+    snapshot_id = f"ctxsnap-v1:{snapshot_hash_value}"
+    if snapshot_envelope["snapshot_hash"] != snapshot_hash_value:
+        _fail("inconsistent", "persisted.snapshot_artifact.snapshot_hash")
+    if snapshot_envelope["snapshot_id"] != snapshot_id:
+        _fail("inconsistent", "persisted.snapshot_artifact.snapshot_id")
+
+    publication = _exact_mapping(
+        _strict_json_bytes(
+            candidates.publication_artifact,
+            _PUBLICATION_MAX_BYTES,
+            "persisted.publication_artifact",
+        ),
+        {
+            "schema",
+            "previous",
+            "snapshot_artifact_hash",
+            "repository_head",
+            "generator_commit",
+            "constitution",
+            "targets",
+        },
+        "persisted.publication_artifact",
+    )
+    if publication["schema"] != _PUBLICATION_SCHEMA:
+        _fail("invalid_schema", "persisted.publication_artifact.schema")
+    targets = _exact_mapping(publication["targets"], set(_TARGETS), "persisted.publication_artifact.targets")
+    if dict(targets) != _TARGETS:
+        _fail("inconsistent", "persisted.publication_artifact.targets")
+    constitution = _exact_mapping(
+        publication["constitution"],
+        {"source_blob", "reviewed_at_commit"},
+        "persisted.publication_artifact.constitution",
+    )
+    previous = _materialize_previous(publication["previous"])
+
+    repository = _exact_mapping(snapshot["repository"], {"name", "head"}, "snapshot.repository")
+    generator = _exact_mapping(snapshot["generator"], {"schema", "repository", "commit"}, "snapshot.generator")
+    snapshot_constitution = _exact_mapping(
+        snapshot["constitution"],
+        {"version", "sha256", "source_blob", "reviewed_at_commit"},
+        "snapshot.constitution",
+    )
+    snapshot_comparison = _exact_mapping(
+        snapshot["comparison_state"],
+        {
+            "gateway_errors_total",
+            "gateway_rejected_parse_total",
+            "gateway_rejected_validate_total",
+            "immune_rollbacks_total",
+        },
+        "snapshot.comparison_state",
+    )
+    if publication["snapshot_artifact_hash"] != _snapshot_artifact_hash(candidates.snapshot_artifact):
+        _fail("inconsistent", "persisted.publication_artifact.snapshot_artifact_hash")
+    if publication["repository_head"] != repository["head"]:
+        _fail("inconsistent", "persisted.publication_artifact.repository_head")
+    if publication["generator_commit"] != generator["commit"]:
+        _fail("inconsistent", "persisted.publication_artifact.generator_commit")
+    if constitution["source_blob"] != snapshot_constitution["source_blob"]:
+        _fail("inconsistent", "persisted.publication_artifact.constitution.source_blob")
+    if constitution["reviewed_at_commit"] != snapshot_constitution["reviewed_at_commit"]:
+        _fail("inconsistent", "persisted.publication_artifact.constitution.reviewed_at_commit")
+    if previous.snapshot_id != snapshot_id:
+        _fail("inconsistent", "persisted.publication_artifact.previous.snapshot_id")
+    if previous.c0_sha256 != snapshot_constitution["sha256"]:
+        _fail("inconsistent", "persisted.publication_artifact.previous.c0_sha256")
+    if dict(previous.comparison_state) != dict(snapshot_comparison):
+        _fail("inconsistent", "persisted.publication_artifact.previous.comparison_state")
+
+    if candidates.claude_md != candidates.agents_md:
+        _fail("inconsistent", "persisted.consumer_outputs")
+    claude_payload, claude_provenance = _parse_root(candidates.claude_md, snapshot)
+    agents_payload, agents_provenance = _parse_root(candidates.agents_md, snapshot)
+    if claude_payload != agents_payload or claude_provenance != agents_provenance:
+        _fail("inconsistent", "persisted.consumer_outputs")
+
+    expected_provenance = {
+        "Payload schema": claude_payload["schema"],
+        "Snapshot schema": snapshot["schema"],
+        "Mode": previous.mode.value,
+        "Snapshot ID": snapshot_id,
+        "Payload hash": payload_hash(claude_payload),
+        "Repository head": repository["head"],
+        "Generator commit": generator["commit"],
+        "Constitution source blob": snapshot_constitution["source_blob"],
+        "Constitution reviewed commit": snapshot_constitution["reviewed_at_commit"],
+    }
+    if dict(claude_provenance) != expected_provenance:
+        _fail("inconsistent", "persisted.root.provenance")
+    if previous.payload_hash != expected_provenance["Payload hash"]:
+        _fail("inconsistent", "persisted.publication_artifact.previous.payload_hash")
+    if previous.consumer_outputs["claude"] != consumer_output_hash(candidates.claude_md):
+        _fail("inconsistent", "persisted.publication_artifact.previous.consumer_outputs.claude")
+    if previous.consumer_outputs["agents"] != consumer_output_hash(candidates.agents_md):
+        _fail("inconsistent", "persisted.publication_artifact.previous.consumer_outputs.agents")
+
+    expected = build_publication_candidates(claude_payload, snapshot)
+    if candidates != expected:
+        _fail("inconsistent", "persisted.generation")
+    return previous
+
+
+def validate_persisted_generation(candidates: PublicationCandidates) -> PreviousPublishedRecord:
+    """Validate four persisted artifact bytes as one generation and return its record."""
+    if type(candidates) is not PublicationCandidates:
+        _fail("invalid_type", "persisted")
+    try:
+        return _validate_persisted_generation(candidates)
+    except ContractViolation:
+        raise
+    except (AttributeError, IndexError, KeyError, RecursionError, TypeError, UnicodeError, ValueError):
+        _fail("invalid_type", "persisted")

--- a/tests/test_context_contract.py
+++ b/tests/test_context_contract.py
@@ -34,6 +34,7 @@ from steward.context_contract import (
     payload_hash,
     snapshot_hash,
     validate_payload_core,
+    validate_previous_published_record,
     validate_public_safe_text,
     validate_snapshot_model,
 )
@@ -493,6 +494,93 @@ class TestModeAndPayloadDecision:
         attestation = self.attestation(c0)
         assert decide_publish("a" * 64, c0, attestation, None, OutputMode.PREVIEW).decision is Decision.BLOCKED
         assert decide_publish("not-a-hash", c0, attestation, None, OutputMode.CANONICAL).decision is Decision.BLOCKED
+
+    def test_previous_record_accepts_nullable_comparison_state(self):
+        candidate = "a" * 64
+        c0 = "b" * 64
+        all_null = PreviousPublishedRecord(
+            payload_hash=candidate,
+            snapshot_id="ctxsnap-v1:" + ("d" * 64),
+            c0_sha256=c0,
+            mode=OutputMode.CANONICAL,
+            consumer_outputs={"agents": "e" * 64, "claude": "e" * 64},
+            comparison_state={
+                "gateway_errors_total": None,
+                "gateway_rejected_parse_total": None,
+                "gateway_rejected_validate_total": None,
+                "immune_rollbacks_total": None,
+            },
+        )
+        validate_previous_published_record(all_null)
+        assert (
+            decide_publish(candidate, c0, self.attestation(c0), all_null, OutputMode.CANONICAL).decision
+            is Decision.NO_OP
+        )
+
+        mixed = PreviousPublishedRecord(
+            payload_hash=candidate,
+            snapshot_id="ctxsnap-v1:" + ("d" * 64),
+            c0_sha256=c0,
+            mode=OutputMode.CANONICAL,
+            consumer_outputs={"agents": "e" * 64, "claude": "e" * 64},
+            comparison_state={
+                "gateway_errors_total": 0,
+                "gateway_rejected_parse_total": None,
+                "gateway_rejected_validate_total": 2,
+                "immune_rollbacks_total": None,
+            },
+        )
+        validate_previous_published_record(mixed)
+
+    @pytest.mark.parametrize("bad_value", [-1, True, 1.5, "1"])
+    def test_previous_record_rejects_invalid_comparison_values(self, bad_value):
+        previous = self.previous("a" * 64, "b" * 64)
+        comparison_state = dict(previous.comparison_state)
+        comparison_state["gateway_errors_total"] = bad_value
+        malformed = PreviousPublishedRecord(
+            payload_hash=previous.payload_hash,
+            snapshot_id=previous.snapshot_id,
+            c0_sha256=previous.c0_sha256,
+            mode=previous.mode,
+            consumer_outputs=previous.consumer_outputs,
+            comparison_state=comparison_state,
+        )
+
+        assert violation_code(validate_previous_published_record, malformed) in {"invalid_type", "invalid_value"}
+        assert (
+            decide_publish(
+                "a" * 64,
+                "b" * 64,
+                self.attestation("b" * 64),
+                malformed,
+                OutputMode.CANONICAL,
+            ).decision
+            is Decision.BLOCKED
+        )
+
+    def test_previous_record_rejects_wrong_record_and_mode_runtime_types(self):
+        assert violation_code(validate_previous_published_record, object()) == "invalid_type"
+
+        previous = self.previous("a" * 64, "b" * 64)
+        malformed = PreviousPublishedRecord(
+            payload_hash=previous.payload_hash,
+            snapshot_id=previous.snapshot_id,
+            c0_sha256=previous.c0_sha256,
+            mode="canonical",  # type: ignore[arg-type]
+            consumer_outputs=previous.consumer_outputs,
+            comparison_state=previous.comparison_state,
+        )
+        assert violation_code(validate_previous_published_record, malformed) == "invalid_type"
+        assert (
+            decide_publish(
+                "a" * 64,
+                "b" * 64,
+                self.attestation("b" * 64),
+                malformed,
+                OutputMode.CANONICAL,
+            ).decision
+            is Decision.BLOCKED
+        )
 
 
 class TestMaterializedModelValidation:

--- a/tests/test_context_rendering.py
+++ b/tests/test_context_rendering.py
@@ -186,6 +186,27 @@ def test_persisted_generation_accepts_separately_read_equal_roots(detached_candi
     assert previous.mode is OutputMode.CANONICAL
 
 
+def test_persisted_generation_accepts_nullable_comparison_state(models):
+    payload, snapshot = models
+    snapshot["comparison_state"] = {
+        "gateway_errors_total": None,
+        "gateway_rejected_parse_total": 1,
+        "gateway_rejected_validate_total": None,
+        "immune_rollbacks_total": 2,
+    }
+    built = build_publication_candidates(payload, snapshot)
+    detached = PublicationCandidates(
+        claude_md=bytes(bytearray(built.claude_md)),
+        agents_md=bytes(bytearray(built.agents_md)),
+        snapshot_artifact=bytes(bytearray(built.snapshot_artifact)),
+        publication_artifact=bytes(bytearray(built.publication_artifact)),
+    )
+
+    previous = validate_persisted_generation(detached)
+
+    assert dict(previous.comparison_state) == snapshot["comparison_state"]
+
+
 def test_publication_artifact_bytes_alone_are_not_a_trusted_record(detached_candidates):
     with pytest.raises(ContractViolation) as exc_info:
         validate_persisted_generation(detached_candidates.publication_artifact)  # type: ignore[arg-type]
@@ -235,6 +256,65 @@ def test_snapshot_and_publication_cross_binding_tamper_blocks(detached_candidate
     tampered_publication = canonical_json_bytes(publication)
     with pytest.raises(ContractViolation):
         validate_persisted_generation(replace(detached_candidates, publication_artifact=tampered_publication))
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.update({"unknown": True}),
+        lambda value: value["previous"].update({"unknown": True}),
+        lambda value: value["targets"].update({"agents": "agents.md"}),
+        lambda value: value["previous"].update({"payload_hash": "0" * 64}),
+        lambda value: value["previous"].update({"c0_sha256": "0" * 64}),
+        lambda value: value["previous"]["consumer_outputs"].update({"agents": "0" * 64}),
+        lambda value: value["previous"].update({"mode": 1}),
+        lambda value: value.update({"repository_head": "0" * 40}),
+        lambda value: value.update({"generator_commit": "0" * 40}),
+        lambda value: value["constitution"].update({"source_blob": "0" * 40}),
+    ],
+)
+def test_publication_schema_provenance_and_hash_tamper_blocks(detached_candidates, mutation):
+    publication = json.loads(detached_candidates.publication_artifact)
+    mutation(publication)
+    tampered = canonical_json_bytes(publication)
+
+    with pytest.raises(ContractViolation):
+        validate_persisted_generation(replace(detached_candidates, publication_artifact=tampered))
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.update({"unknown": True}),
+        lambda value: value.update({"snapshot_id": "ctxsnap-v1:" + ("0" * 64)}),
+        lambda value: value.update({"snapshot_hash": "0" * 64}),
+        lambda value: value["snapshot"]["orientation"].update({"sha256": "0" * 64}),
+    ],
+)
+def test_snapshot_schema_and_hash_tamper_blocks(detached_candidates, mutation):
+    snapshot = json.loads(detached_candidates.snapshot_artifact)
+    mutation(snapshot)
+    tampered = canonical_json_bytes(snapshot)
+
+    with pytest.raises(ContractViolation):
+        validate_persisted_generation(replace(detached_candidates, snapshot_artifact=tampered))
+
+
+@pytest.mark.parametrize(
+    ("old", "new"),
+    [
+        (b"Repository head: `1111111111111111111111111111111111111111`", b"Repository head: `" + b"0" * 40 + b"`"),
+        (b'"provider":"healthy"', b'"provider":"unknown"'),
+        (b'"status":"empty"', b'"status":"valid"'),
+    ],
+)
+def test_dynamic_provenance_and_observation_tamper_blocks(detached_candidates, old, new):
+    assert old in detached_candidates.claude_md
+    root = detached_candidates.claude_md.replace(old, new, 1)
+    tampered = replace(detached_candidates, claude_md=root, agents_md=bytes(bytearray(root)))
+
+    with pytest.raises(ContractViolation):
+        validate_persisted_generation(tampered)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_context_rendering.py
+++ b/tests/test_context_rendering.py
@@ -12,10 +12,11 @@ from pathlib import Path
 
 import pytest
 
-from steward.context_contract import ContractViolation, consumer_output_hash
+from steward.context_contract import ContractViolation, OutputMode, canonical_json_bytes, consumer_output_hash
 from steward.context_rendering import (
     PublicationCandidates,
     build_publication_candidates,
+    validate_persisted_generation,
     validate_publication_candidates,
 )
 
@@ -31,6 +32,18 @@ def models():
 def expected():
     path = Path("specs/context_bridge_evidence/FEATURE_01_PUBLICATION_VECTORS.json")
     return json.loads(path.read_text())
+
+
+@pytest.fixture
+def detached_candidates(models):
+    payload, snapshot = models
+    built = build_publication_candidates(payload, snapshot)
+    return PublicationCandidates(
+        claude_md=bytes(bytearray(built.claude_md)),
+        agents_md=bytes(bytearray(built.agents_md)),
+        snapshot_artifact=bytes(bytearray(built.snapshot_artifact)),
+        publication_artifact=bytes(bytearray(built.publication_artifact)),
+    )
 
 
 def test_golden_generation_is_exact_and_byte_identical(models, expected):
@@ -160,3 +173,84 @@ def test_module_imports_are_pure_and_fixture_free():
     assert "ServiceRegistry" not in source
     assert "assemble_context" not in source
     assert "specs/" not in source
+
+
+def test_persisted_generation_accepts_separately_read_equal_roots(detached_candidates, expected):
+    assert detached_candidates.claude_md == detached_candidates.agents_md
+    assert detached_candidates.claude_md is not detached_candidates.agents_md
+
+    previous = validate_persisted_generation(detached_candidates)
+
+    assert previous.payload_hash == expected["publication_artifact"]["expected_payload_hash"]
+    assert previous.snapshot_id == expected["publication_artifact"]["expected_snapshot_id"]
+    assert previous.mode is OutputMode.CANONICAL
+
+
+def test_publication_artifact_bytes_alone_are_not_a_trusted_record(detached_candidates):
+    with pytest.raises(ContractViolation) as exc_info:
+        validate_persisted_generation(detached_candidates.publication_artifact)  # type: ignore[arg-type]
+    assert exc_info.value.code == "invalid_type"
+
+
+@pytest.mark.parametrize("field", PublicationCandidates.__dataclass_fields__)
+def test_each_persisted_artifact_tamper_blocks(detached_candidates, field):
+    tampered = replace(detached_candidates, **{field: getattr(detached_candidates, field) + b"x"})
+    with pytest.raises(ContractViolation):
+        validate_persisted_generation(tampered)
+
+
+def test_distinct_root_bytes_block(detached_candidates):
+    tampered = replace(detached_candidates, agents_md=detached_candidates.agents_md.replace(b"Steward", b"steward", 1))
+    with pytest.raises(ContractViolation) as exc_info:
+        validate_persisted_generation(tampered)
+    assert exc_info.value.code == "inconsistent"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda root: b"prefix\n" + root,
+        lambda root: root + b"\n",
+        lambda root: root.replace(b"<!-- steward-context:dynamic:v1:end -->", b"", 1),
+        lambda root: root.replace(b"### Observations", b"### Injected\n\n### Observations", 1),
+        lambda root: root[:-1],
+    ],
+)
+def test_root_structure_tamper_blocks(detached_candidates, mutation):
+    root = mutation(detached_candidates.claude_md)
+    tampered = replace(detached_candidates, claude_md=root, agents_md=bytes(bytearray(root)))
+    with pytest.raises(ContractViolation):
+        validate_persisted_generation(tampered)
+
+
+def test_snapshot_and_publication_cross_binding_tamper_blocks(detached_candidates):
+    snapshot_artifact = json.loads(detached_candidates.snapshot_artifact)
+    snapshot_artifact["snapshot"]["comparison_state"]["gateway_errors_total"] = None
+    tampered_snapshot = canonical_json_bytes(snapshot_artifact)
+    with pytest.raises(ContractViolation):
+        validate_persisted_generation(replace(detached_candidates, snapshot_artifact=tampered_snapshot))
+
+    publication = json.loads(detached_candidates.publication_artifact)
+    publication["previous"]["comparison_state"]["gateway_errors_total"] = None
+    tampered_publication = canonical_json_bytes(publication)
+    with pytest.raises(ContractViolation):
+        validate_persisted_generation(replace(detached_candidates, publication_artifact=tampered_publication))
+
+
+@pytest.mark.parametrize(
+    ("field", "bad_bytes"),
+    [
+        ("claude_md", b"x" * 65_537),
+        ("agents_md", b"x" * 65_537),
+        ("snapshot_artifact", b"x" * 131_073),
+        ("publication_artifact", b"x" * 16_385),
+        ("snapshot_artifact", b"\xef\xbb\xbf{}"),
+        ("snapshot_artifact", b"\xff"),
+        ("snapshot_artifact", b'{"schema":NaN}'),
+        ("snapshot_artifact", b'{"schema":"x","schema":"x"}'),
+        ("snapshot_artifact", b'{ "schema": "x" }'),
+    ],
+)
+def test_persisted_input_boundaries_and_noncanonical_json_block(detached_candidates, field, bad_bytes):
+    with pytest.raises(ContractViolation):
+        validate_persisted_generation(replace(detached_candidates, **{field: bad_bytes}))


### PR DESCRIPTION
## Scope

Implements only Feature 01 / Slice D1 approved by PR #627:

- public structural validator for materialized `PreviousPublishedRecord`
- nullable `comparison_state` semantics shared with the snapshot contract
- strict pure four-artifact persisted-generation read-back
- exact root/envelope/cross-hash/provenance reconstruction
- separately read byte-equal roots accepted without object-identity assumptions

Still excluded: filesystem access, publisher, writer, lock, recovery, bootstrap, caller wiring, workflow, settings, delivery, and activation.

## Commit structure

1. `24bdb0c2` — direct red tests against the previously missing APIs
2. `0214e3c8` — implementation plus additional adversarial cases

## Verification

- targeted D1/contract suite: `124 passed`
- sampled single-byte mutation scan: `338` mutations rejected
- full suite first run: stopped after `274 passed, 1 skipped` on an unrelated Cetana/Dharma teardown timeout
- that exact autonomous-flow test isolated: `1 passed`
- all remaining tests: `2287 passed, 1 skipped, 1 deselected`
- `ruff check steward/ tests/`: pass
- `ruff format --check steward/ tests/`: 215 files formatted
- `bandit -r steward/ -c pyproject.toml -q`: pass
- `git diff --check`: pass

The full-suite timeout stack does not touch any changed path and passed when reproduced in isolation. Test-created runtime health diffs were removed before push.
