### PR TITLE
docs: heartbeat failure propagation evidence & feature spec (recon complete)

### DIFF
--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
@@ -1,0 +1,125 @@
+# HEARTBEAT-FEHLERPROPAGATION — FEATURE-SPEC 01
+
+## Sichtbarmachung anhaltenden kognitiven/Provider-Kollaps
+
+> **Status:** DRAFT 0.1 — NICHT G1; ZUR ADVERSARIALEN KRITIK; IMPLEMENTIERUNG UND
+> AKTIVIERUNG GESPERRT
+> **Datum:** 2026-07-17
+> **Produktionsbasis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
+> **Herkunft:** Phase-2 §7.3; Recon RECON_01–04 in `heartbeat_failure_propagation_evidence/`
+
+---
+
+## 1. Zweck und Gate
+
+Einen **anhaltenden** kognitiven/Provider-Kollaps beobachtbar machen, ohne die bewusste
+Resilienz des Heartbeats (Daemon stirbt nicht an transienten Fehlern) zu brechen. Zuerst
+reine Sichtbarkeit (LOGGING), Erzwingen (Run rot) erst nach belegter Beobachtung und nur
+hinter Kill-Switch.
+
+Dies ist ein DRAFT. Aus ihm darf kein Patch abgeleitet werden. Gate G1 wird erst nach
+adversarialem Review (§10) und Operator-Go erteilt.
+
+## 2. Normative Abhängigkeiten
+
+- `heartbeat_failure_propagation_evidence/RECON_01_SWALLOW_PATHS.md` (vier Schluck-Schichten)
+- `RECON_02_CONSUMPTION_AND_CLASSES.md` (None-Konsum, vorhandene Klassifikation)
+- `RECON_03_ADVERSARIAL.md` (Befund-Umkehrung: Erkennung vorhanden, Aussenverdrahtung fehlt)
+- `RECON_04_PERSISTENCE_AND_EXTERNAL.md` (in-memory-only, konsolidierte Fehlerklassen-Matrix)
+
+## 3. Gepinnter Ist-Zustand (belegt)
+
+- Kollaps wird erkannt: `vedana.py:78` (`_W_PROVIDER = 0.35`) → `dharma.py:56`
+  (`health < 0.3 → ctx.health_anomaly = True`).
+- Erkennung wirkt nur nach innen: `engine.py:310` (Runden kappen + LLM-Guidance). Kein
+  Exit/Alert.
+- Kaskade endet `return None` (`chamber.py:325`), Harness schluckt (`steward-heartbeat.yml:
+  83–90`, Exit 0). Resilienz — bewusst.
+- Kollaps-Zustand ist **in-memory only** (`chamber.py:114–121`; kein Disk-Write von
+  `_total_failures`/`_last_reset`) → **über Runs blind**.
+- Persistierter Health-Report hat **kein** Provider-/Kognitions-Feld
+  (`moksha_health.py:62–94`).
+- `chamber.stats()` liefert `total_failures`, `total_calls`, `providers[].alive`
+  (`chamber.py:440`, konsumiert `engine.py:356–360`).
+- Vorhandenes Aussensignal-Muster: `dharma.py:187–214` (GitHub-Issue, Label
+  `federation-health`) — heute nur für Peers.
+
+## 4. Scope und Nicht-Scope
+
+**In Scope:** ein persistierter Run-übergreifender Kollaps-Zähler; ein Provider-/
+Kognitions-Feld im vorhandenen Health-Report; optionale Eskalation über das vorhandene
+`dharma`-Issue-Muster; optionale, kill-switch-gesicherte Run-Signalisierung.
+
+**Nicht-Scope:** kein `raise` in `chamber`; keine Änderung der Workflow-`try/except`-
+Resilienz; keine neue Kaskaden-/Provider-Logik; Context-Bridge, Identität, Key-Rotation,
+Quarantäne unberührt. Kein Sammelpatch.
+
+## 5. Zielarchitektur (Vorschlag, angreifbar)
+
+1. **Kollaps-Signal je Run ermitteln** aus `chamber.stats()` am Run-Ende (MOKSHA): ist der
+   Run vollständig kollabiert (0 alive / alle Provider tot über den Run)? Reine Ableitung
+   aus vorhandenem `stats()`, keine neue Zählung.
+2. **Persistierter Zähler** in bereits über Runs persistiertem State (`.steward/`):
+   `consecutive_collapsed_runs`. +1 bei Voll-Kollaps-Run, Reset auf 0 bei einem Run mit
+   ≥1 erfolgreicher Kognition. Das ist der fehlende Run-übergreifende Zustand.
+3. **Sichtbarkeit (Slice A):** Provider-/Kognitions-Block in `_build_health_report`
+   (`alive/total`, `total_failures`, `consecutive_collapsed_runs`). Nur schreiben/loggen —
+   **kein** Einfluss auf Run-Ausgang.
+4. **Eskalation (Slice B):** ab Schwelle `consecutive_collapsed_runs ≥ N` das vorhandene
+   `dharma`-Issue-Muster für Selbst-Kollaps wiederverwenden (Label z. B. `steward-health`).
+   Kein Run-Rot.
+5. **Erzwingen (Slice C, optional, kill-switch):** erst nach Beobachtung — bei Schwelle den
+   Run als nicht-erfolgreich signalisieren (Exit≠0 im Heartbeat-Schritt), hinter
+   Feature-Flag/Kill-Switch, Default AUS.
+
+## 6. Verpflichtende Implementierungsschnitte (getrennt, je eigener G2)
+
+- **Schnitt A — Sichtbarkeit:** Zähler + Health-Feld. Null Verhaltensänderung am Run-Ausgang.
+  Produktionsbeweis: Feld erscheint, Run bleibt grün, transienter Ausfall erhöht den Zähler
+  NICHT.
+- **Schnitt B — Eskalation:** Issue-Muster-Wiederverwendung. Kein Run-Rot.
+- **Schnitt C — Erzwingen:** kill-switch-gesicherte Run-Signalisierung. Nur nach A/B +
+  belegter Schwelle.
+
+Kein Schnitt darf mit einem anderen in einen Sammel-PR.
+
+## 7. Testvertrag
+
+- Gegen die **echte** `ProviderChamber` testen, kein Stub (Phase-1 §220.3).
+- Voll-Kollaps-Run (alle Cells tot) → Zähler +1, Health-Feld gesetzt.
+- **Guard gegen Fehlalarm:** ein einzelner transienter Ausfall mit erfolgreichem Fallback →
+  Zähler bleibt/geht 0. (Der Guard, der die transient/kritisch-Grenze verteidigt.)
+- Reset: ein Run mit ≥1 erfolgreicher Kognition → Zähler 0.
+- Schnitt A ändert den Run-Exit-Status in **keinem** Fall.
+
+## 8. Aktivierung, Kill-Switch, LOGGING-vor-Erzwingen
+
+Schnitt A/B sind reine Beobachtung/Alarm, kein Run-Rot. Schnitt C ist per Default AUS und
+nur über expliziten Kill-Switch aktivierbar. Verifikation immer am **Produktionslog**, nicht
+am grünen Test.
+
+## 9. Rollback
+
+Jeder Schnitt ist einzeln reversibel: Health-Feld/Zähler entfernen bzw. Kill-Switch AUS.
+Da Schnitt A/B den Run-Ausgang nicht ändern, ist ihr Blast-Radius auf Datenfelder begrenzt.
+
+## 10. Offene Fragen — BITTE ADVERSARIAL ANGREIFEN (vor G1)
+
+1. **Schwelle N** für „anhaltend über Runs" ist noch nicht belegt — sie darf **nicht**
+   geraten werden, sondern muss aus Produktionsbeobachtung (Schnitt A) kommen. Bis dahin
+   ist Schnitt C gesperrt.
+2. **Trägt der Health-Report** die richtige Semantik, oder braucht der Zähler ein eigenes,
+   atomar geschriebenes Feld? (Freshness/Concurrency — der Heartbeat ist Single-Writer via
+   Workflow-Concurrency-Group, aber der Write muss zum bestehenden State-Commit atomar sein.)
+3. **Reflektiert `chamber.stats()` am MOKSHA-Zeitpunkt den ganzen Run** oder nur den letzten
+   Zyklus? RECON_04 zeigt `_total_failures` kumuliert (kein Per-Zyklus-Reset) — bei
+   Implementierung am Live-Code erneut pinnen.
+4. **Voll-Kollaps-Definition:** „0 alive Cells" vs. „keine erfolgreiche Kognition im Run" —
+   letzteres ist robuster (ein Provider kann alive und trotzdem erfolglos sein). Zu
+   entscheiden.
+5. **Interagiert der `_maybe_reset_daily`** (`chamber.py:522`) mit der Zähler-Semantik?
+
+## 11. Schlussstatus
+
+DRAFT 0.1. Kein G1, keine Implementierung, keine Aktivierung. Nächster Schritt: adversariales
+Review von §5/§10, dann — nach Operator-Go — G1-fähige Fassung.

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
@@ -2,7 +2,7 @@
 
 ## Sichtbarmachung anhaltenden kognitiven/Provider-Kollaps
 
-> **Status:** DRAFT 0.1 — NICHT G1; ZUR ADVERSARIALEN KRITIK; IMPLEMENTIERUNG UND
+> **Status:** DRAFT 0.2 — SCHNITT A AUSFÜHRBAR SPEZIFIZIERT; NICHT G1; IMPLEMENTIERUNG UND
 > AKTIVIERUNG GESPERRT
 > **Datum:** 2026-07-17
 > **Produktionsbasis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
@@ -12,114 +12,152 @@
 
 ## 1. Zweck und Gate
 
-Einen **anhaltenden** kognitiven/Provider-Kollaps beobachtbar machen, ohne die bewusste
-Resilienz des Heartbeats (Daemon stirbt nicht an transienten Fehlern) zu brechen. Zuerst
-reine Sichtbarkeit (LOGGING), Erzwingen (Run rot) erst nach belegter Beobachtung und nur
-hinter Kill-Switch.
+Anhaltenden kognitiven/Provider-Kollaps beobachtbar machen, ohne die bewusste Resilienz
+(Daemon stirbt nicht an transienten Fehlern) zu brechen. LOGGING zuerst; Erzwingen (Run rot)
+erst nach belegter Beobachtung und nur hinter Kill-Switch.
 
-Dies ist ein DRAFT. Aus ihm darf kein Patch abgeleitet werden. Gate G1 wird erst nach
-adversarialem Review (§10) und Operator-Go erteilt.
+DRAFT. Kein G1 ohne adversariales Review (§10) und Operator-Go. **Schnitt A** ist hier so
+spezifiziert, dass er ohne Interpretationsspielraum umsetzbar ist. **Schnitt B/C** sind
+bewusst datengesteuert gegated (nicht geraten).
 
 ## 2. Normative Abhängigkeiten
 
-- `heartbeat_failure_propagation_evidence/RECON_01_SWALLOW_PATHS.md` (vier Schluck-Schichten)
-- `RECON_02_CONSUMPTION_AND_CLASSES.md` (None-Konsum, vorhandene Klassifikation)
-- `RECON_03_ADVERSARIAL.md` (Befund-Umkehrung: Erkennung vorhanden, Aussenverdrahtung fehlt)
-- `RECON_04_PERSISTENCE_AND_EXTERNAL.md` (in-memory-only, konsolidierte Fehlerklassen-Matrix)
+RECON_01–04 (`heartbeat_failure_propagation_evidence/`). Alle Zeilenanker gelten auf der
+Produktionsbasis oben und sind vor Implementierung erneut zu pinnen.
 
-## 3. Gepinnter Ist-Zustand (belegt)
+## 3. Gepinnte Fakten (belegt, mit Anker)
 
-- Kollaps wird erkannt: `vedana.py:78` (`_W_PROVIDER = 0.35`) → `dharma.py:56`
-  (`health < 0.3 → ctx.health_anomaly = True`).
-- Erkennung wirkt nur nach innen: `engine.py:310` (Runden kappen + LLM-Guidance). Kein
-  Exit/Alert.
-- Kaskade endet `return None` (`chamber.py:325`), Harness schluckt (`steward-heartbeat.yml:
-  83–90`, Exit 0). Resilienz — bewusst.
-- Kollaps-Zustand ist **in-memory only** (`chamber.py:114–121`; kein Disk-Write von
-  `_total_failures`/`_last_reset`) → **über Runs blind**.
-- Persistierter Health-Report hat **kein** Provider-/Kognitions-Feld
-  (`moksha_health.py:62–94`).
-- `chamber.stats()` liefert `total_failures`, `total_calls`, `providers[].alive`
-  (`chamber.py:440`, konsumiert `engine.py:356–360`).
-- Vorhandenes Aussensignal-Muster: `dharma.py:187–214` (GitHub-Issue, Label
-  `federation-health`) — heute nur für Peers.
+- `chamber.stats()` → `chamber.py:423`; liefert `{"providers":[{"name","alive",…}],
+  "total_calls":int, "total_failures":int, …}`.
+- Chamber ist Service: Klasse `SVC_PROVIDER` `services.py:40`; Registrierung
+  `services.py:285` (`ServiceRegistry.register(SVC_PROVIDER, provider)`); Get-Muster wie
+  `context_bridge.py:271` (`ServiceRegistry.get(SVC_PROVIDER)`).
+- Health-Report-Builder `_build_health_report()` `moksha_health.py:62`; Writer/Execute
+  `moksha_health.py:39–59`; Zieldateien `.steward/federation_health.json` und
+  `data/federation/steward_health.json` (plain `write_text`, **nicht** atomar).
+- Health-Hook registriert: `hooks/__init__.py:66` (`MokshaHealthReportHook`). Läuft pro
+  MOKSHA-Zyklus.
+- **Kein** Once-per-Run/Shutdown-Phasen-Hook (bestätigt); nur Per-Zyklus-Hooks. Prozess-
+  `close()` `agent.py:742` ist kein Phasen-Hook → nicht genutzt. ⇒ Streak-Granularität =
+  **pro Zyklus**.
+- `.steward/federation_health.json` wird vom Heartbeat committet (`steward-heartbeat.yml:99`
+  `git add -u -- .steward/`) ⇒ über Runs persistent.
 
 ## 4. Scope und Nicht-Scope
 
-**In Scope:** ein persistierter Run-übergreifender Kollaps-Zähler; ein Provider-/
-Kognitions-Feld im vorhandenen Health-Report; optionale Eskalation über das vorhandene
-`dharma`-Issue-Muster; optionale, kill-switch-gesicherte Run-Signalisierung.
+**In Scope (Schnitt A):** ein `cognition`-Block im vorhandenen Health-Report inkl. eines über
+Runs persistierten Zyklus-Streak-Zählers. **Kein** Einfluss auf Run-Exit-Status.
 
 **Nicht-Scope:** kein `raise` in `chamber`; keine Änderung der Workflow-`try/except`-
-Resilienz; keine neue Kaskaden-/Provider-Logik; Context-Bridge, Identität, Key-Rotation,
-Quarantäne unberührt. Kein Sammelpatch.
+Resilienz; keine Atomicity-Änderung am bestehenden Health-Write (vorbestehend, eigener
+Hygiene-Punkt); Context-Bridge/Identität/Rotation/Quarantäne unberührt. Kein Sammelpatch.
 
-## 5. Zielarchitektur (Vorschlag, angreifbar)
+## 5. SCHNITT A — AUSFÜHRBARER VERTRAG (Sichtbarkeit)
 
-1. **Kollaps-Signal je Run ermitteln** aus `chamber.stats()` am Run-Ende (MOKSHA): ist der
-   Run vollständig kollabiert (0 alive / alle Provider tot über den Run)? Reine Ableitung
-   aus vorhandenem `stats()`, keine neue Zählung.
-2. **Persistierter Zähler** in bereits über Runs persistiertem State (`.steward/`):
-   `consecutive_collapsed_runs`. +1 bei Voll-Kollaps-Run, Reset auf 0 bei einem Run mit
-   ≥1 erfolgreicher Kognition. Das ist der fehlende Run-übergreifende Zustand.
-3. **Sichtbarkeit (Slice A):** Provider-/Kognitions-Block in `_build_health_report`
-   (`alive/total`, `total_failures`, `consecutive_collapsed_runs`). Nur schreiben/loggen —
-   **kein** Einfluss auf Run-Ausgang.
-4. **Eskalation (Slice B):** ab Schwelle `consecutive_collapsed_runs ≥ N` das vorhandene
-   `dharma`-Issue-Muster für Selbst-Kollaps wiederverwenden (Label z. B. `steward-health`).
-   Kein Run-Rot.
-5. **Erzwingen (Slice C, optional, kill-switch):** erst nach Beobachtung — bei Schwelle den
-   Run als nicht-erfolgreich signalisieren (Exit≠0 im Heartbeat-Schritt), hinter
-   Feature-Flag/Kill-Switch, Default AUS.
+### 5.1 Kollaps-Prädikat (rein aus `stats()`, kein Delta)
+```
+pstats = ServiceRegistry.get(SVC_PROVIDER).stats()
+providers = pstats["providers"]
+alive  = sum(1 for p in providers if p.get("alive"))
+total  = len(providers)
+collapsed = (total > 0 and alive == 0)
+```
 
-## 6. Verpflichtende Implementierungsschnitte (getrennt, je eigener G2)
+### 5.2 Persistierter Zyklus-Streak (Lesen-vor-Überschreiben)
+Vor dem Überschreiben den vorherigen Streak aus der bestehenden Zieldatei lesen:
+```
+prev = 0
+try:
+    prev = json.loads(Path(".steward/federation_health.json").read_text())\
+             .get("cognition", {}).get("consecutive_collapsed_cycles", 0)
+except (OSError, ValueError):
+    prev = 0
+streak = prev + 1 if collapsed else 0
+```
 
-- **Schnitt A — Sichtbarkeit:** Zähler + Health-Feld. Null Verhaltensänderung am Run-Ausgang.
-  Produktionsbeweis: Feld erscheint, Run bleibt grün, transienter Ausfall erhöht den Zähler
-  NICHT.
-- **Schnitt B — Eskalation:** Issue-Muster-Wiederverwendung. Kein Run-Rot.
-- **Schnitt C — Erzwingen:** kill-switch-gesicherte Run-Signalisierung. Nur nach A/B +
-  belegter Schwelle.
+### 5.3 Report-Erweiterung
+`_build_health_report()` (`moksha_health.py:62`) erhält Signatur
+`_build_health_report(prev_streak: int = 0)` und ergänzt vor `return report`:
+```
+provider = ServiceRegistry.get(SVC_PROVIDER)
+report["cognition"] = {"providers_alive": 0, "providers_total": 0,
+                       "total_calls": 0, "total_failures": 0,
+                       "collapsed": False, "consecutive_collapsed_cycles": prev_streak}
+if provider is not None and hasattr(provider, "stats"):
+    ps = provider.stats()
+    providers = ps.get("providers", [])
+    alive = sum(1 for p in providers if p.get("alive"))
+    total = len(providers)
+    collapsed = (total > 0 and alive == 0)
+    report["cognition"] = {
+        "providers_alive": alive, "providers_total": total,
+        "total_calls": ps.get("total_calls", 0),
+        "total_failures": ps.get("total_failures", 0),
+        "collapsed": collapsed,
+        "consecutive_collapsed_cycles": (prev_streak + 1 if collapsed else 0),
+    }
+```
+`execute()` (`moksha_health.py:39`) liest `prev` (5.2) und ruft
+`_build_health_report(prev_streak=prev)`. Writer und Dateien **unverändert**.
 
-Kein Schnitt darf mit einem anderen in einen Sammel-PR.
+### 5.4 Invariante
+Schnitt A ändert **keinen** Kontrollfluss außerhalb `moksha_health.py`, wirft nicht, ändert
+den Run-Exit-Status in **keinem** Fall. Nur ein zusätzliches Datenfeld.
 
-## 7. Testvertrag
+## 6. SCHNITT A — TESTVERTRAG (exakt, echte Klassen, kein Stub)
 
-- Gegen die **echte** `ProviderChamber` testen, kein Stub (Phase-1 §220.3).
-- Voll-Kollaps-Run (alle Cells tot) → Zähler +1, Health-Feld gesetzt.
-- **Guard gegen Fehlalarm:** ein einzelner transienter Ausfall mit erfolgreichem Fallback →
-  Zähler bleibt/geht 0. (Der Guard, der die transient/kritisch-Grenze verteidigt.)
-- Reset: ein Run mit ≥1 erfolgreicher Kognition → Zähler 0.
-- Schnitt A ändert den Run-Exit-Status in **keinem** Fall.
+Datei `tests/test_moksha_health.py` (neu oder erweitert). Gegen echte `ProviderChamber`
+(`build_chamber()`-artig konstruiert), via `ServiceRegistry.register(SVC_PROVIDER, chamber)`.
 
-## 8. Aktivierung, Kill-Switch, LOGGING-vor-Erzwingen
+- `test_cognition_block_present_and_healthy`: 2 lebende Cells → `report["cognition"]`
+  existiert; `providers_total == 2`; `providers_alive == 2`; `collapsed is False`;
+  `consecutive_collapsed_cycles == 0`.
+- `test_collapse_increments_streak`: alle Cells nicht-alive → `collapsed is True`;
+  `_build_health_report(prev_streak=3)` ⇒ `consecutive_collapsed_cycles == 4`.
+- `test_transient_resets_streak` (**Guard §220.3**): ≥1 lebende Cell, `prev_streak=5`
+  ⇒ `collapsed is False`; `consecutive_collapsed_cycles == 0`.
+- `test_no_provider_registered`: SVC_PROVIDER nicht registriert ⇒ `cognition`-Block mit
+  `providers_total == 0`, `consecutive_collapsed_cycles == prev_streak`; kein Fehler.
+- `test_execute_appends_ok_and_returns_none`: `execute(ctx)` gibt `None`, hängt
+  `"moksha_health_report:ok"` an `ctx.operations` an, wirft nicht (Invariante 5.4).
 
-Schnitt A/B sind reine Beobachtung/Alarm, kein Run-Rot. Schnitt C ist per Default AUS und
-nur über expliziten Kill-Switch aktivierbar. Verifikation immer am **Produktionslog**, nicht
-am grünen Test.
+## 7. SCHNITT A — AKZEPTANZ (Produktionslog, nicht grüner Test)
+
+Nach einem Heartbeat-Run gilt: `.steward/federation_health.json` enthält den `cognition`-
+Block mit den sechs Feldern; bei lebenden Providern `consecutive_collapsed_cycles: 0`; der
+Run-Exit-Status ist unverändert grün. Verifikation am realen Artefakt + Run-Log.
+
+## 8. SCHNITT B/C — PRÄZISE GEGATED (nicht geraten)
+
+- **B (Eskalation):** erst nachdem A in Produktion Daten geliefert hat. Wiederverwendung des
+  vorhandenen Issue-Musters (`dharma.py:187`, heute Peer-scoped) für Selbst-Kollaps. Eigene
+  G2-Spec. Ändert Run-Ausgang **nicht**.
+- **C (Erzwingen/Run-rot):** GESPERRT bis (i) A-Beobachtung die Schwelle `N`
+  (`consecutive_collapsed_cycles ≥ N`) empirisch begründet und (ii) das Prädikat (5.1)
+  ggf. auf „keine erfolgreiche Kognition" verschärft ist. Hinter Feature-Flag/Kill-Switch,
+  Default AUS. Eigene G2-Spec + Operator-Go.
 
 ## 9. Rollback
 
-Jeder Schnitt ist einzeln reversibel: Health-Feld/Zähler entfernen bzw. Kill-Switch AUS.
-Da Schnitt A/B den Run-Ausgang nicht ändern, ist ihr Blast-Radius auf Datenfelder begrenzt.
+Schnitt A: `cognition`-Block + Signaturänderung entfernen. Blast-Radius = ein Datenfeld,
+kein Kontrollfluss.
 
-## 10. Offene Fragen — BITTE ADVERSARIAL ANGREIFEN (vor G1)
+## 10. Offene Fragen
 
-1. **Schwelle N** für „anhaltend über Runs" ist noch nicht belegt — sie darf **nicht**
-   geraten werden, sondern muss aus Produktionsbeobachtung (Schnitt A) kommen. Bis dahin
-   ist Schnitt C gesperrt.
-2. **Trägt der Health-Report** die richtige Semantik, oder braucht der Zähler ein eigenes,
-   atomar geschriebenes Feld? (Freshness/Concurrency — der Heartbeat ist Single-Writer via
-   Workflow-Concurrency-Group, aber der Write muss zum bestehenden State-Commit atomar sein.)
-3. **Reflektiert `chamber.stats()` am MOKSHA-Zeitpunkt den ganzen Run** oder nur den letzten
-   Zyklus? RECON_04 zeigt `_total_failures` kumuliert (kein Per-Zyklus-Reset) — bei
-   Implementierung am Live-Code erneut pinnen.
-4. **Voll-Kollaps-Definition:** „0 alive Cells" vs. „keine erfolgreiche Kognition im Run" —
-   letzteres ist robuster (ein Provider kann alive und trotzdem erfolglos sein). Zu
-   entscheiden.
-5. **Interagiert der `_maybe_reset_daily`** (`chamber.py:522`) mit der Zähler-Semantik?
+**Geschlossen durch DRAFT 0.2:** Chamber-Erreichbarkeit (SVC_PROVIDER), Persistenz-Ort
+(bestehende committete `federation_health.json`), Granularität (pro Zyklus, da kein
+Once-per-Run-Hook), Andockstelle (`moksha_health.py`).
+
+**Bewusst offen — datengesteuert, NICHT vor Beobachtung entscheidbar (Angriffsfläche fürs
+Review):**
+1. Schwelle `N` für „kritisch" — muss aus A-Produktionsdaten kommen, darf nicht geraten
+   werden. Sperrt C.
+2. Prädikat-Verschärfung „alive==0" → „keine erfolgreiche Kognition im Zyklus" (braucht
+   Zyklus-Delta von `total_calls`/`total_failures`) — für C, nicht für A.
+3. Nicht-Atomicity des bestehenden Health-Writes (`write_text`) — vorbestehend; als eigener
+   Hygiene-Punkt zu führen, nicht in dieser Feature.
 
 ## 11. Schlussstatus
 
-DRAFT 0.1. Kein G1, keine Implementierung, keine Aktivierung. Nächster Schritt: adversariales
-Review von §5/§10, dann — nach Operator-Go — G1-fähige Fassung.
+DRAFT 0.2. Schnitt A ausführbar; B/C korrekt gegated. Kein G1, keine Implementierung, keine
+Aktivierung ohne adversariales Review von §5/§8/§10 und Operator-Go.

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
@@ -79,6 +79,13 @@ Sie schreibt **nicht** in `docs/PHASE2_BEFUND.md`, `docs/PHASE2_CURRENT.md` oder
 |---|---|---|
 | `heartbeat_failure_propagation_evidence/RECON_01_SWALLOW_PATHS.md` | Die vier Schluck-Schichten, am Code belegt | RECON — teils offen |
 | `heartbeat_failure_propagation_evidence/RECON_02_CONSUMPTION_AND_CLASSES.md` | None-Konsum (Event, nicht verkabelt), bestehende Fehlerklassifikation, Andockpunkt `health_anomaly` | RECON — teils offen |
+| `heartbeat_failure_propagation_evidence/RECON_03_ADVERSARIAL.md` | Gegenbeweis-Versuch: Claim hält; Befund umgedreht — Erkennung vorhanden, Aussenverdrahtung fehlt; Fix-Richtung korrigiert (nicht `raise`) | RECON — teils offen |
+
+**Befund-Korrektur (RECON_03):** Der Kern ist nicht „der Heartbeat schluckt Fehler" (das
+Schlucken ist plausibel bewusste Resilienz), sondern „eine bereits vorhandene Kollaps-
+Erkennung (`vedana` Provider-Puls → `health_anomaly`) ist nur nach innen verdrahtet oder
+verwaist". Zielrichtung: vorhandene Erkennung bei *anhaltendem* Kollaps nach außen sichtbar
+machen — LOGGING zuerst, kein erzwungenes Rot vor Beobachtung.
 
 ## 5. NÄCHSTER GATE
 

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
@@ -1,0 +1,85 @@
+# HEARTBEAT-FEHLERPROPAGATION — MASTER-SYSTEMSPEZIFIKATION
+
+> **Status:** DRAFT 0.1 — RECON-PHASE; NOCH KEINE FEATURE-SPEC; IMPLEMENTIERUNG UND
+> AKTIVIERUNG GESPERRT
+> **Datum:** 2026-07-17
+> **Produktionsbasis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
+> **Plan-Herkunft:** Phase-2 `docs/PHASE2_CURRENT.md` §7.3 (Heartbeat-Fehlerpropagation)
+> **Sperre:** Aus diesem Dokument darf noch kein Produktivpatch abgeleitet werden. Erst nach
+> abgeschlossenem Recon und separat reviewter Feature-Spec wird ein kleinster Root-Cause-
+> Patch autorisiert.
+
+---
+
+## 0. WARUM DIESE BAUSTELLE EXISTIERT
+
+Der Steward-Heartbeat ist das zentrale Lebens- und Gesundheitssignal der Föderation. Ein
+grüner Heartbeat-Run wird — von Menschen wie von Folgeagenten — als „das Fundament ist
+gesund" gelesen.
+
+Der Recon (siehe `heartbeat_failure_propagation_evidence/RECON_01_SWALLOW_PATHS.md`) belegt
+am Code: **der Heartbeat-Run ist strukturell unfähig, an kognitivem, Hook- oder
+Provider-Versagen rot zu werden.** Vier unabhängige `try/except`-Schichten fangen jeden
+Fehler ab, loggen ihn (teils unterhalb der sichtbaren Log-Schwelle) und lassen den Prozess
+mit Exit 0 enden.
+
+Konsequenz: Das grüne Signal ist als Gesundheitsaussage über die Kognition **wertlos**. Das
+ist exakt Phase-1 §220.3 (*„Ein leeres Log sieht aus wie Erfolg. Verifizieren am
+Produktionslog, nie am grünen Test."*) — nur strukturell verankert. Die Erkennung existiert
+(Log-Zeilen); die **Verdrahtung zum Run-Status fehlt** (klassisch: gebaut, nicht verkabelt).
+
+Diese Grenze ist sicherheitskritisch, weil die gesamte Beweisdisziplin des Projekts —
+jeder „Produktionsrun grün"-Nachweis — auf einem Signal ruht, das aktuell lügen kann.
+
+## 0A. LEITPLANKEN (nicht verhandelbar)
+
+- Die Föderation läuft durch dieses Gate. **Erst LOGGING-/Beobachtungsmodus, dann
+  erzwingen** (Phase-1 §220). Kein blindes `raise`, das ein transienter Provider-429 zum
+  Föderations-Stillstand eskalieren lässt.
+- Kein Rewrite, kein zweiter paralleler Heartbeat, kein monolithischer PR, keine
+  Implementierung aus Chat-Prosa, keine Freigabe ohne Produktionslog-Beweis.
+- Nur der Code zählt, nicht Kommentare oder `CLAUDE.md` (Phase-1 §220.3).
+- Verifiziert wird am **Produktionslog**, nicht am grünen Test.
+
+## 1. ZWECK (Zielrichtung, noch nicht Vertrag)
+
+Fehlerklassen des Heartbeats trennen, statt sie pauschal zu schlucken:
+
+- **kritisch** → muss den Run rot machen (z. B. Total-Provider-Kollaps über einen ganzen
+  Zyklus, Bootstrap-/Identitätsfehler);
+- **degradierbar** → toleriert, aber sichtbar und gezählt (z. B. ein transienter
+  Provider-Ausfall mit erfolgreichem Fallback);
+- **extern / Post-Action** → toleriert und getrennt geführt (z. B. entfernte Zustellung).
+
+Die konkrete Zuordnung wird **nicht hier**, sondern erst nach vollständigem Recon in einer
+eigenen Feature-Spec festgelegt.
+
+## 2. SCOPE / NICHT-SCOPE (vorläufig)
+
+**In Scope:** die vier belegten Schluck-Schichten im Heartbeat-Pfad (Provider-Kaskade,
+Hook-Dispatch, Workflow-Harness, interner Phasen-Dispatcher) und ihre Verdrahtung zum
+Run-Exit-Status.
+
+**Nicht in Scope (getrennte Baustellen):** die Context-Bridge (eigener Agent, eigene
+Ordner `CONTEXT_BRIDGE_*` / `context_bridge_evidence/`), Identitäts-Rename, Key-Rotation,
+Quarantäne-Cleanup. Kein Sammelpatch.
+
+## 3. ISOLATION (gegen Parallel-Agenten-Merge-Konflikte)
+
+Diese Baustelle lebt **ausschließlich** in:
+- `specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md` (dieses Dokument)
+- `specs/heartbeat_failure_propagation_evidence/**`
+
+Sie schreibt **nicht** in `docs/PHASE2_BEFUND.md`, `docs/PHASE2_CURRENT.md` oder in
+`context_bridge_*`-Pfade. Dadurch entstehen keine Merge-Kollisionen mit anderen Agenten.
+
+## 4. EVIDENZ-INDEX
+
+| Dok | Inhalt | Status |
+|---|---|---|
+| `heartbeat_failure_propagation_evidence/RECON_01_SWALLOW_PATHS.md` | Die vier Schluck-Schichten, am Code belegt | RECON — teils offen |
+
+## 5. NÄCHSTER GATE
+
+Recon fortsetzen (offene Punkte in RECON_01 §8), bis die Fehlerklassen-Matrix vollständig
+belegt ist. Erst danach: separate Feature-Spec, dann kleinster Patch im LOGGING-Modus.

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
@@ -79,7 +79,8 @@ Sie schreibt **nicht** in `docs/PHASE2_BEFUND.md`, `docs/PHASE2_CURRENT.md` oder
 |---|---|---|
 | `heartbeat_failure_propagation_evidence/RECON_01_SWALLOW_PATHS.md` | Die vier Schluck-Schichten, am Code belegt | RECON — teils offen |
 | `heartbeat_failure_propagation_evidence/RECON_02_CONSUMPTION_AND_CLASSES.md` | None-Konsum (Event, nicht verkabelt), bestehende Fehlerklassifikation, Andockpunkt `health_anomaly` | RECON — teils offen |
-| `heartbeat_failure_propagation_evidence/RECON_03_ADVERSARIAL.md` | Gegenbeweis-Versuch: Claim hält; Befund umgedreht — Erkennung vorhanden, Aussenverdrahtung fehlt; Fix-Richtung korrigiert (nicht `raise`) | RECON — teils offen |
+| `heartbeat_failure_propagation_evidence/RECON_03_ADVERSARIAL.md` | Gegenbeweis-Versuch: Claim hält; Befund umgedreht — Erkennung vorhanden, Aussenverdrahtung fehlt; Fix-Richtung korrigiert (nicht `raise`) | EVIDENCE |
+| `heartbeat_failure_propagation_evidence/RECON_04_PERSISTENCE_AND_EXTERNAL.md` | Kollaps-Zustand nur in-memory (über Runs blind); Push-Fehler geschluckt+ungezählt; konsolidierte Fehlerklassen-Matrix | EVIDENCE COMPLETE |
 
 **Befund-Korrektur (RECON_03):** Der Kern ist nicht „der Heartbeat schluckt Fehler" (das
 Schlucken ist plausibel bewusste Resilienz), sondern „eine bereits vorhandene Kollaps-
@@ -89,5 +90,10 @@ machen — LOGGING zuerst, kein erzwungenes Rot vor Beobachtung.
 
 ## 5. NÄCHSTER GATE
 
-Recon fortsetzen (offene Punkte in RECON_01 §8), bis die Fehlerklassen-Matrix vollständig
-belegt ist. Erst danach: separate Feature-Spec, dann kleinster Patch im LOGGING-Modus.
+**Recon abgeschlossen (RECON_01–04).** Die Fehlerklassen-Matrix ist vollständig belegt
+(RECON_04 §5). Kein offener Recon-Punkt ist vor der Spec zwingend.
+
+Nächster Gate = **eigene Feature-Spec** (Format wie Context Bridge). Zielarchitektur:
+vorhandene `vedana`/`health_anomaly`-Erkennung bei *anhaltendem* Kollaps nach außen
+sichtbar machen + persistierter Kollaps-Zähler über Runs; LOGGING vor Erzwingen; Rollback.
+**Kein Produktcode und keine Feature-Spec ohne ausdrückliches Operator-Go.**

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
@@ -93,7 +93,8 @@ machen — LOGGING zuerst, kein erzwungenes Rot vor Beobachtung.
 **Recon abgeschlossen (RECON_01–04).** Die Fehlerklassen-Matrix ist vollständig belegt
 (RECON_04 §5). Kein offener Recon-Punkt ist vor der Spec zwingend.
 
-Nächster Gate = **eigene Feature-Spec** (Format wie Context Bridge). Zielarchitektur:
-vorhandene `vedana`/`health_anomaly`-Erkennung bei *anhaltendem* Kollaps nach außen
-sichtbar machen + persistierter Kollaps-Zähler über Runs; LOGGING vor Erzwingen; Rollback.
-**Kein Produktcode und keine Feature-Spec ohne ausdrückliches Operator-Go.**
+Feature-Spec liegt als **DRAFT** vor: `HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`
+(Status DRAFT 0.1 — NICHT G1). Zielarchitektur: vorhandene `vedana`/`health_anomaly`-
+Erkennung bei *anhaltendem* Kollaps nach außen sichtbar machen + persistierter Kollaps-
+Zähler über Runs; LOGGING vor Erzwingen; Rollback. Nächster Schritt: adversariales Review
+der DRAFT-Spec (§10 dort). **Kein G1, kein Produktcode ohne ausdrückliches Operator-Go.**

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
@@ -78,6 +78,7 @@ Sie schreibt **nicht** in `docs/PHASE2_BEFUND.md`, `docs/PHASE2_CURRENT.md` oder
 | Dok | Inhalt | Status |
 |---|---|---|
 | `heartbeat_failure_propagation_evidence/RECON_01_SWALLOW_PATHS.md` | Die vier Schluck-Schichten, am Code belegt | RECON — teils offen |
+| `heartbeat_failure_propagation_evidence/RECON_02_CONSUMPTION_AND_CLASSES.md` | None-Konsum (Event, nicht verkabelt), bestehende Fehlerklassifikation, Andockpunkt `health_anomaly` | RECON — teils offen |
 
 ## 5. NÄCHSTER GATE
 

--- a/specs/heartbeat_failure_propagation_evidence/RECON_01_SWALLOW_PATHS.md
+++ b/specs/heartbeat_failure_propagation_evidence/RECON_01_SWALLOW_PATHS.md
@@ -1,0 +1,128 @@
+# HEARTBEAT-FEHLERPROPAGATION — RECON 01: SCHLUCK-PFADE
+
+> **Status:** EVIDENCE PARTIAL — VIER SCHLUCK-SCHICHTEN BELEGT; FEHLERKLASSEN-ZUORDNUNG OFFEN
+> **Datum:** 2026-07-17
+> **Code-Basis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
+> **Scope:** Read-only Recon des Heartbeat-Ausführungspfads; keine Code-Änderung
+
+---
+
+## 1. Frage
+
+Kann ein Heartbeat-Run rot werden, wenn die Kognition versagt — insbesondere bei
+Total-Erschöpfung der Provider-Kaskade? Oder endet der Run strukturell immer grün?
+
+## 2. Der Prod-Ausführungspfad (belegt)
+
+Der Produktions-Heartbeat läuft als GitHub-Action-Schritt
+(`.github/workflows/steward-heartbeat.yml`), der einen Inline-`python -c`-Block startet
+(Z. 68). Dieser Block ruft für `CYCLES` Zyklen (Default 4) je vier Phasen **direkt** auf:
+
+```
+('GENESIS', agent._phase_genesis)
+('DHARMA',  agent._phase_dharma)
+('KARMA',   lambda: agent.run_autonomous_sync(idle_minutes=15))
+('MOKSHA',  agent._phase_moksha)
+```
+
+Kein `set -e`-Abbruch auf Phasenfehler, kein `continue-on-error`, kein `|| echo`. Der
+Exit-Status des Schritts = Exit-Status des Python-Prozesses.
+
+## 3. Die vier Schluck-Schichten (am Code belegt)
+
+Jede Schicht fängt Fehler ab, ohne sie zum Exit-Status zu propagieren:
+
+| # | Ort | Verhalten | Log-Level | Sichtbar bei `INFO`? |
+|---|---|---|---|---|
+| L1 | `steward/provider/chamber.py:314–325` | Provider-Kaskade erschöpft → `return None` (kein `raise`) | `error` | ja |
+| L2 | `steward/phase_hook.py:162–174` | jeder Hook-Fehler → `logger.warning`, `continue` | `warning` | ja |
+| L3a | `.github/workflows/steward-heartbeat.yml:83–90` | jeder Phasenfehler → `logger.error` + `traceback`, weiter; Prozess endet Exit 0 | `error` | ja |
+| L3b | `steward/agent.py:763–766` (`_run_phase`) | interner Phasenfehler → `logger.debug("… non-fatal")` | `debug` | **nein** |
+
+### Belege (verbatim)
+
+**L1 — `chamber.py:319–325`:**
+```python
+logger.error(
+    "ALL providers exhausted (%d total, %d alive, %d failures)",
+    len(self._cells), alive_count, self._total_failures,
+)
+return None
+```
+`invoke()` dokumentiert selbst (Z. 223): *„Returns NormalizedResponse or None if all
+providers exhausted."* Kein `raise`. Der Aufrufer erhält `None`.
+
+**L2 — `phase_hook.py:173–174`:**
+```python
+except Exception as e:
+    logger.warning("Hook %s failed: %s", hook.name, e)
+```
+Der Loop über die Hooks läuft nach dem `except` weiter (`continue`-Semantik).
+
+**L3a — `steward-heartbeat.yml:83–90`:**
+```python
+try:
+    phase_fn()
+except Exception as e:
+    logger.error('%s failed: %s', phase_name, e)
+    traceback.print_exc()
+```
+Nach der Doppelschleife endet das Script normal → **Exit 0 → Workflow grün.**
+
+**L3b — `agent.py:763–766`:**
+```python
+try:
+    handler()
+except Exception as e:
+    logger.debug("Cetana phase %s error (non-fatal): %s", phase.name, e)
+```
+Der Heartbeat setzt `logging.basicConfig(level=logging.INFO)`. `debug < INFO` → diese
+Schicht ist im Produktionslog **unsichtbar**. Hinweis: L3b liegt auf dem internen
+Cetana-Daemon-Pfad; der Prod-Heartbeat nutzt L3a. Beide existieren.
+
+## 4. Zentraler Befund
+
+Der Heartbeat-Run ist **strukturell unfähig, an kognitivem, Hook- oder Provider-Versagen
+rot zu werden.** Selbst ein Total-Provider-Kollaps über alle Zyklen endet Exit 0. Das
+einzige Signal ist eine Log-Zeile (L1 `error`), auf die **kein Gate** prüft.
+
+Das grüne Heartbeat-Signal ist damit als Aussage über kognitive Gesundheit wertlos —
+strukturell, nicht zufällig. Deckt sich mit den wiederkehrenden Live-Beobachtungen
+(Provider-Degradation Groq 401 / Gemini 429 / Mistral 400 bei „erfolgreichem" Run,
+`docs/PHASE2_CURRENT.md` §5) und mit Phase-1 §220.3.
+
+## 5. Wirkungsvertrag (Zielrichtung, noch nicht Spec)
+
+Die pauschalen `except Exception` sind das Problem. Ziel ist eine Fehlerklassen-Trennung
+(kritisch → rot / degradierbar → toleriert+sichtbar / extern → getrennt), zunächst im
+LOGGING-/Beobachtungsmodus verdrahtet, bevor irgendetwas rot erzwingt.
+
+## 6. Blast-Radius / Warum vorsichtig
+
+Die Föderation läuft durch dieses Gate. Ein naives „raise" auf L1 würde einen transienten
+Provider-Ausfall zum Föderations-Stillstand eskalieren. Deshalb ist die Fehlerklassen-
+Zuordnung (was ist wirklich kritisch?) der eigentliche Kern und muss vollständig belegt
+sein, bevor ein Patch entsteht.
+
+## 7. Sicherheitsauswirkung
+
+Keine (read-only). Das Dokument ändert kein Verhalten. Es dokumentiert eine bestehende,
+belegte Fundament-Schwäche.
+
+## 8. Offen / noch nicht belegt (nächste Recon-Runde)
+
+1. **Konsum von `None` aus `invoke()`**: Wo genau (Conversation-Engine, `AutonomyEngine`)
+   wird das `None` bei Provider-Kollaps konsumiert? Führt es zu stillem No-op oder zu einer
+   Exception, die dann in L2/L3 landet? (`agent.py:428` reicht den Provider weiter.)
+2. **Fehlerklassen-Matrix**: Welche konkreten Exception-Typen / Zustände sind *kritisch*
+   vs. *degradierbar*? (`QuotaExceededError` in `chamber.py:236` als erster Kandidat.)
+3. **Zyklus- vs. Einzelaufruf-Granularität**: Ein einzelner Provider-Ausfall ≠ Kollaps über
+   einen ganzen Zyklus. Wo ist die richtige Grenze für „kritisch"?
+4. **Bestehende Sichtbarkeits-Infrastruktur**: Gibt es bereits einen Health-/Anomalie-Pfad
+   (`ctx.health_anomaly` in `agent.py:790`), an den sich eine Fehlerpropagation
+   anschließen ließe, statt neu zu bauen? (Phase-1-Prinzip: erst grep, ob es existiert.)
+
+## 9. Gate-Wirkung
+
+Recon nicht abgeschlossen. Kein Feature-Spec-, Implementierungs- oder Aktivierungs-Gate
+freigegeben. Nächster Schritt: offene Punkte §8 belegen.

--- a/specs/heartbeat_failure_propagation_evidence/RECON_02_CONSUMPTION_AND_CLASSES.md
+++ b/specs/heartbeat_failure_propagation_evidence/RECON_02_CONSUMPTION_AND_CLASSES.md
@@ -1,0 +1,104 @@
+# HEARTBEAT-FEHLERPROPAGATION — RECON 02: NONE-KONSUM, FEHLERKLASSEN, ANDOCKPUNKT
+
+> **Status:** EVIDENCE PARTIAL — KONSUM UND KLASSIFIKATION BELEGT; SPEC NOCH NICHT FÄLLIG
+> **Datum:** 2026-07-17
+> **Code-Basis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
+> **Scope:** Read-only Recon der offenen Punkte aus RECON_01 §8; keine Code-Änderung
+> **Verifikation:** `engine.py:305–369` von Opus direkt gelesen; übrige Anker per Sub-Agent
+> (Explore, verbatim) geholt und gegen RECON_01 gegengeprüft.
+
+---
+
+## 1. Fragen (aus RECON_01 §8)
+
+Wo wird `None` aus der Kaskade konsumiert? Welche Fehlerklassen unterscheidet der Code
+bereits? Wo ist die richtige Kritisch-Grenze? Existiert ein Andockpunkt statt Neubau?
+
+## 2. None-Konsum — belegt (Präzisierung von RECON_01 L1)
+
+Der Provider wandert in die `AgentLoop` (`agent.py:427–428`), gespeichert in
+`loop/engine.py:164`. `.invoke()` wird in `engine.py:805` gerufen. Der Rückgabewert `None`
+wird **nicht still verworfen**, sondern als Event ausgegeben (`engine.py:352–365`):
+
+```python
+if response is None:
+    diag = "LLM returned no response"
+    if isinstance(self._provider, ChamberProvider):
+        ...
+        diag = f"All providers failed ({n_fail} failures / {n_total} calls)"
+    yield AgentEvent(type=EventType.ERROR, content=diag)
+    return
+```
+
+**Präzisierung:** RECON_01 zeigte `return None` in der Kaskade als „geschluckt". Genauer: der
+Kollaps wird eine Ebene höher als **`EventType.ERROR`-Event sichtbar gemacht** — aber der
+Loop `return`t danach normal (kein `raise`). Das Signal existiert also als Event; die
+Verdrahtung zum Run-Exit-Status fehlt weiterhin. Es ist „sichtbar-als-Event, nicht
+verkabelt", nicht „komplett stumm". Fünfter Surfacing-Punkt, gleiches Muster.
+
+## 3. Fehlerklassen — der Code klassifiziert bereits (grep-before-build)
+
+Eine transient/non-transient-Unterscheidung existiert schon in der Kaskade:
+
+- `_is_transient(e)` — `chamber.py:85–88`; Transient-Tabelle `chamber.py:47–61`.
+- Retry-Klassifikation `chamber.py:289–303`:
+```python
+except Exception as e:
+    last_error = e
+    if attempt < _MAX_RETRIES and _is_transient(e):
+        continue
+    break  # non-transient or retries exhausted → next provider
+```
+- `QuotaExceededError` (import `chamber.py:30`) → `return None` bei `chamber.py:236–238`.
+
+Heißt: die *degradierbar*-Achse (transient, Fallback greift) ist bereits im Code angelegt.
+Was fehlt, ist die *kritisch*-Achse und ihre Propagation.
+
+## 4. Granularität — die Kritisch-Grenze ist im Code lokalisierbar
+
+`invoke()` iteriert über die lebenden Cells (`chamber.py:242 for cell in alive:`).
+- Einzel-Provider-Ausfall → `continue` (`chamber.py:316`), nächster Provider.
+- **Total-Kaskade erschöpft** → `chamber.py:318–325` (`logger.error("ALL providers
+  exhausted…")` + `return None`).
+
+Die natürliche Kritisch-Grenze ist also **nicht** der Einzelausfall (der ist per Design
+degradierbar), sondern **Total-Erschöpfung** — und schärfer: Total-Erschöpfung, die über
+einen ganzen Zyklus anhält. Der Einzelausfall darf grün bleiben; der anhaltende Kollaps
+nicht.
+
+## 5. Andockpunkt — existiert, kein Neubau nötig
+
+Es gibt bereits einen Erkennungs→Verhalten-Kanal für Gesundheit:
+
+- SET: `hooks/dharma.py:57` `ctx.health_anomaly = True`; zurückgelesen `agent.py:790–793`;
+  Cetana direkt `agent.py:838`. Feld: `phase_hook.py:52–53`.
+- KONSUM (einziger): `engine.py:310–323` — verwendet `health_anomaly` **ausschließlich**,
+  um `max_rounds` zu kappen und dem LLM eine USER-Guidance („finish immediately")
+  einzuspielen.
+
+**Belegt (von Opus gelesen):** dieser Kanal beeinflusst **nicht** den Exit-Status, `raise`t
+nicht, ändert das Run-Ergebnis nicht. Also: der Detektions-Kanal ist vorhanden und verdrahtet
+— aber sein Verhalten ist „schneller fertigwerden", nicht „Run rot". Er ist der natürliche
+Andockpunkt für eine Kritisch-Propagation (erweitern, nicht neu bauen), im LOGGING-Modus
+zuerst.
+
+## 6. Zwischenstand Fehlerklassen-Matrix (Entwurf, nicht normativ)
+
+| Klasse | Beispiel (belegt) | Heute | Zielverhalten (Vorschlag, gehört in Feature-Spec) |
+|---|---|---|---|
+| degradierbar | transienter Ausfall, Fallback greift (`chamber.py:289–303`) | grün, Fallback | grün + gezählt/sichtbar |
+| kritisch | Total-Kaskade über Zyklus (`chamber.py:318–325`) | grün (Exit 0) | sichtbar → später rot (erst LOGGING) |
+| extern/Post-Action | (noch nicht zerlegt) | — | getrennt geführt |
+
+## 7. Offen / nächster Schritt
+
+- „extern/Post-Action"-Klasse noch nicht zerlegt (Remote-Delivery, `git`-Push im MOKSHA).
+- Anhaltend-über-Zyklus messbar machen: welcher Zustand hält den Kollaps über
+  Zyklusgrenzen fest? (`chamber.stats()`/`_total_failures` als Kandidat.)
+- Danach — und erst dann — ist die Feature-Spec fällig: kleinster Eingriff am belegten
+  Andockpunkt (§5), LOGGING zuerst.
+
+## 8. Gate-Wirkung
+
+Recon weit fortgeschritten, aber nicht abgeschlossen. Kein Implementierungs- oder
+Aktivierungs-Gate freigegeben. Kein Produktcode berührt.

--- a/specs/heartbeat_failure_propagation_evidence/RECON_02_CONSUMPTION_AND_CLASSES.md
+++ b/specs/heartbeat_failure_propagation_evidence/RECON_02_CONSUMPTION_AND_CLASSES.md
@@ -70,7 +70,7 @@ nicht.
 
 Es gibt bereits einen Erkennungs→Verhalten-Kanal für Gesundheit:
 
-- SET: `hooks/dharma.py:57` `ctx.health_anomaly = True`; zurückgelesen `agent.py:790–793`;
+- SET: `hooks/dharma.py:56–57` (`if v.health < 0.3:` Z.56 → `ctx.health_anomaly = True` Z.57); zurückgelesen `agent.py:790–793`;
   Cetana direkt `agent.py:838`. Feld: `phase_hook.py:52–53`.
 - KONSUM (einziger): `engine.py:310–323` — verwendet `health_anomaly` **ausschließlich**,
   um `max_rounds` zu kappen und dem LLM eine USER-Guidance („finish immediately")

--- a/specs/heartbeat_failure_propagation_evidence/RECON_03_ADVERSARIAL.md
+++ b/specs/heartbeat_failure_propagation_evidence/RECON_03_ADVERSARIAL.md
@@ -36,7 +36,7 @@ wird sehr wohl gemessen:
 - `vedana.py:78` `_W_PROVIDER = 0.35` (höchstes Gewicht; Kommentar Z.74: *„Provider health
   is most critical — no provider = agent is dead"*), `vedana.py:115`
   `p_health = provider_alive / max(provider_total, 1)`. 0 lebende Provider → Puls sinkt.
-- `dharma.py:56` `if v.health < 0.3: ctx.health_anomaly = True`.
+- `dharma.py:56–57` (`if v.health < 0.3:` Z.56 → `ctx.health_anomaly = True` Z.57).
 
 Der Kollaps erzeugt also ein Health-Anomalie-Signal. **Aber jeder Aktuator dieses Signals
 zeigt nach INNEN oder ist verwaist** — nichts zeigt nach außen. Das ist exakt „alles
@@ -46,7 +46,7 @@ gebaut, nichts verdrahtet", nur präzise lokalisiert.
 
 | Signal | Erzeugt in | Aktuator / Leser | Nach außen sichtbar? |
 |---|---|---|---|
-| `health_anomaly`-Flag | `dharma.py:56` | nur `engine.py:310` — kappt Tool-Runden + spielt LLM-Guidance ein | **nein** |
+| `health_anomaly`-Flag | `dharma.py:56–57` | nur `engine.py:310` — kappt Tool-Runden + spielt LLM-Guidance ein | **nein** |
 | `AGENT_ERROR`-Signal | `agent_bus.py:180` (SignalBus) | **kein In-Repo-Subscriber** | **nein** |
 | `federation_health.json` / `steward_health.json` | `moksha_health.py:39` | **kein Code-Leser** (nur Docs referenzieren) | **nein** |
 | Feld im Health-Report | `moksha_health.py:62` — `peers/immune/gateway` | — | **kein Provider-/Kognitions-Feld überhaupt** |

--- a/specs/heartbeat_failure_propagation_evidence/RECON_03_ADVERSARIAL.md
+++ b/specs/heartbeat_failure_propagation_evidence/RECON_03_ADVERSARIAL.md
@@ -1,0 +1,86 @@
+# HEARTBEAT-FEHLERPROPAGATION — RECON 03: ADVERSARIALES GEGENBEWEIS-REVIEW
+
+> **Status:** EVIDENCE — KERNBEHAUPTUNG HÄLT; BEFUND UMGEDREHT: NICHT FEHLENDE ERKENNUNG,
+> SONDERN FEHLENDE AUSSENVERDRAHTUNG
+> **Datum:** 2026-07-17
+> **Code-Basis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
+> **Scope:** Read-only. Aktiver Versuch, RECON_01/02 zu WIDERLEGEN (Phase-1 §220.3).
+> **Verifikation:** `vedana.py:74–118` und `engine.py:305–369` von Opus direkt gelesen;
+> übrige Anker per Sub-Agent (Explore, verbatim) geholt, gegen RECON_01/02 gegengeprüft.
+
+---
+
+## 1. Vorgehen
+
+Getestete Behauptung (**Claim C**): *Der Heartbeat hat KEINEN Mechanismus, der einen
+anhaltenden kognitiven/Provider-Kollaps an ein beobachtbares Run-Ergebnis propagiert —
+kein Exit-Status, kein fehlschlagender Check, kein Alert, kein von einem Gate/Menschen
+konsumiertes Health-Flag, kein separater Monitoring-Workflow.* Ziel war, C zu **kippen**.
+
+## 2. Ergebnis: kein Gegenbeweis
+
+- **Workflows:** `self-heal.yml:20–24` triggert nur auf Workflow `"CI"`, nicht auf den
+  Heartbeat. `ci.yml:5–9` läuft nur auf push/PR, liest keinen Heartbeat-State.
+  `post-merge.yml`, `publish*.yml`: kein Health-Reader, kein Alert. → kein Gegenbeweis.
+- **Tests:** `test_agent.py:677` prüft nur ein internes `ERROR`-**Event** bei Erschöpfung;
+  kein Test prüft Exit-Status oder Run-Ausgang. → kein Gegenbeweis.
+
+Claim C **hält** — jetzt belegt, nicht nur behauptet.
+
+## 3. Die Umkehrung (was der Angriff aufdeckte)
+
+Der Versuch, C zu widerlegen, hat das Gegenteil des naiven Bildes gezeigt: **Das Problem
+ist nicht fehlende Erkennung — die Erkennung ist überreichlich gebaut.** Provider-Kollaps
+wird sehr wohl gemessen:
+
+- `vedana.py:78` `_W_PROVIDER = 0.35` (höchstes Gewicht; Kommentar Z.74: *„Provider health
+  is most critical — no provider = agent is dead"*), `vedana.py:115`
+  `p_health = provider_alive / max(provider_total, 1)`. 0 lebende Provider → Puls sinkt.
+- `dharma.py:56` `if v.health < 0.3: ctx.health_anomaly = True`.
+
+Der Kollaps erzeugt also ein Health-Anomalie-Signal. **Aber jeder Aktuator dieses Signals
+zeigt nach INNEN oder ist verwaist** — nichts zeigt nach außen. Das ist exakt „alles
+gebaut, nichts verdrahtet", nur präzise lokalisiert.
+
+## 4. Verwaiste / nur-nach-innen verdrahtete Signale (belegt)
+
+| Signal | Erzeugt in | Aktuator / Leser | Nach außen sichtbar? |
+|---|---|---|---|
+| `health_anomaly`-Flag | `dharma.py:56` | nur `engine.py:310` — kappt Tool-Runden + spielt LLM-Guidance ein | **nein** |
+| `AGENT_ERROR`-Signal | `agent_bus.py:180` (SignalBus) | **kein In-Repo-Subscriber** | **nein** |
+| `federation_health.json` / `steward_health.json` | `moksha_health.py:39` | **kein Code-Leser** (nur Docs referenzieren) | **nein** |
+| Feld im Health-Report | `moksha_health.py:62` — `peers/immune/gateway` | — | **kein Provider-/Kognitions-Feld überhaupt** |
+
+Die reichste Erkennung (`vedana` Provider-Puls) landet im Health-Report **gar nicht**, und
+die Flags, die sie setzt, verpuffen nach innen.
+
+## 5. Wiederverwendbares Muster (grep-before-build)
+
+`dharma.py:187–214` erzeugt bei erschöpfter Diagnose bereits ein **GitHub-Issue** (Label
+`federation-health`) — aber **scoped auf nicht-responsive Föderations-PEERS**, nicht auf den
+eigenen Provider-/Kognitions-Kollaps des Stewards. Das ist ein *vorhandenes* Außensignal-
+Muster, das sich für Selbst-Kollaps wiederverwenden ließe, statt neu zu bauen.
+
+## 6. Korrigierte Fix-Richtung (wichtig — ändert RECON_01)
+
+RECON_01 klang nach „der Heartbeat schluckt, also lass ihn rot werden". Der adversariale
+Pass korrigiert das:
+
+- Das Schlucken auf Workflow-Ebene ist **plausibel bewusste Resilienz** (ein Daemon soll
+  bei transientem Provider-429 nicht sterben). Ein naives `raise` wäre falsch.
+- Der eigentliche Defekt ist die **fehlende Aussenverdrahtung einer bereits vorhandenen
+  Erkennung.** Zielrichtung daher: das vorhandene `vedana`/`health_anomaly`-Signal bei
+  **anhaltendem** Kollaps nach außen sichtbar machen — zuerst als Feld im Health-Report +
+  Log, dann optional Gate/Alert über das vorhandene `dharma`-Issue-Muster. **LOGGING
+  zuerst**, kein erzwungenes Rot vor Beobachtung.
+
+## 7. Offen (unverändert)
+
+- Zyklus-übergreifende Persistenz des Kollaps-Zustands (anhaltend vs. transient) — welcher
+  Zustand hält das über Zyklusgrenzen? (`chamber.stats()` / `_total_failures`.)
+- „extern/Post-Action"-Klasse (MOKSHA-Push) noch nicht zerlegt.
+
+## 8. Gate-Wirkung
+
+Recon deutlich gestärkt und korrigiert, aber nicht abgeschlossen (§7 offen). Kein Feature-
+Spec-, Implementierungs- oder Aktivierungs-Gate freigegeben. Kein Produktcode berührt.

--- a/specs/heartbeat_failure_propagation_evidence/RECON_04_PERSISTENCE_AND_EXTERNAL.md
+++ b/specs/heartbeat_failure_propagation_evidence/RECON_04_PERSISTENCE_AND_EXTERNAL.md
@@ -1,0 +1,82 @@
+# HEARTBEAT-FEHLERPROPAGATION — RECON 04: PERSISTENZ & EXTERNE KLASSE
+
+> **Status:** EVIDENCE COMPLETE — RECON ABGESCHLOSSEN; FEATURE-SPEC IST DER NÄCHSTE GATE
+> **Datum:** 2026-07-17
+> **Code-Basis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
+> **Scope:** Read-only. Schließt RECON_03 §7 (Zyklus-Persistenz, externe/Post-Action-Klasse).
+> **Verifikation:** `moksha.py:118–137` von Opus gelesen; `_total_failures`/`_last_reset`/
+> `build_chamber` per Opus-Grep bestätigt (nur `chamber.py`, kein Disk-Write); übrige Anker
+> per Sub-Agent (Explore, verbatim).
+
+---
+
+## 1. Fragen (aus RECON_03 §7)
+
+Wie lange „hält" ein Kollaps (transient vs. anhaltend), und wo ist der Zustand dafür? Und:
+ist die externe/Post-Action-Klasse (Föderations-Push) kritisch oder degradierbar?
+
+## 2. Persistenz des Kollaps-Zustands — belegt: nur in-memory
+
+Der Kollaps-Zustand lebt ausschließlich im `ProviderChamber`-Dataclass (`chamber.py:114–121`:
+`_breakers`, `_last_reset`, `_total_calls`, `_total_failures`; Zell-Integrität/prana). Er
+wird **nicht auf Platte geschrieben**: `_total_failures`/`_last_reset` erscheinen (Opus-Grep)
+nur in `chamber.py` (Increment `:495`, Lesen `:323/:415/:440`, Reset `:525/:533`) — kein
+Write nach `.steward/*.json` oder `data/federation/*.json`. `build_chamber()` baut bei jedem
+Prozess-Start eine **frische** Chamber (`__main__.py:284,471`). Einziger Clearing-Pfad:
+`_maybe_reset_daily` (`chamber.py:522–534`) bei Datumswechsel.
+
+**Daraus folgen drei Ebenen von „anhaltend" — und die dritte ist der blinde Fleck:**
+
+| Ebene | Beispiel | Messbar? | Wo |
+|---|---|---|---|
+| transient | ein Call scheitert, Fallback greift | ja, per Design toleriert | `chamber.py:289–303` |
+| anhaltend **im Run** | alle Provider tot über die 4 Zyklen *eines* Prozesses | ja, in-memory | `_total_failures`, alive-count, breaker |
+| anhaltend **über Runs** | Kollaps über viele 15-Min-Runs hinweg | **NEIN — Zustand wird je Run verworfen** | — (keine Disk-Persistenz) |
+
+## 3. Die entscheidende Asymmetrie
+
+Der Heartbeat **persistiert Föderations-State** (`.steward/`, `data/federation/`) über Runs
+— aber **nicht die Provider-/Kognitions-Gesundheit.** Der einzige geschriebene Health-Report
+(`moksha_health.py:62–94`) enthält `peers/immune/gateway` und **kein Provider-/Kognitions-
+Feld.** Genau die Dimension, die einen mehr-Run-anhaltenden Kollaps sichtbar machen würde,
+wird weggeworfen. Das ist der Kern für die spätere Spec: die „kritisch"-Klasse
+(anhaltend über Runs) braucht einen **persistierten** Kollaps-Zähler, weil die In-Memory-
+Chamber über Runs blind ist.
+
+## 4. Externe/Post-Action-Klasse (Föderations-Push) — belegt: geschluckt UND ungezählt
+
+`git_nadi_sync.push()` gibt bei Fehler `False` zurück, `raise`t nie (`git_nadi_sync.py:
+154–171`). Aufrufstelle `moksha.py:132–135`:
+```python
+git_sync = ServiceRegistry.get(SVC_GIT_NADI_SYNC)
+if git_sync is not None:
+    git_sync.push()
+```
+Der Rückgabewert wird **nicht zugewiesen/geprüft**; `relay.push_to_hub()` nur für eine
+Log-Zeile genutzt. Kein `ctx.operations.append` (im Gegensatz zu
+`moksha_health.py:59 "…:ok"`). Propagation nach außen: **ABSENT** — Delivery-Fehler ist
+weder im Exit-Status noch im Health-Report noch in einem Flag sichtbar.
+
+Einordnung: Delivery-Fehler ist eine **degradierbare** Klasse (transiente Remote-/Netz-
+Probleme sollen den Daemon nicht töten), aber sie ist heute nicht nur toleriert, sondern
+**unsichtbar** — kein Tracking.
+
+## 5. Konsolidierte Fehlerklassen-Matrix (Recon-Ergebnis, Basis für die Feature-Spec)
+
+| Klasse | Belegter Trigger | Heute | Zielverhalten (gehört in Feature-Spec) |
+|---|---|---|---|
+| transient | Einzel-Call scheitert, Fallback greift (`chamber.py:289`) | grün, Fallback | grün + gezählt |
+| anhaltend-im-Run | alle Provider tot über Zyklen (`chamber.py:318`) | grün, nur `logger.error` | sichtbar (Health-Feld + Log) |
+| anhaltend-über-Runs | Kollaps über mehrere Runs | **unsichtbar** (Zustand verworfen) | **persistierter Zähler → kritisch, LOGGING zuerst** |
+| extern/Post-Action | Push scheitert (`moksha.py:135`) | geschluckt + ungezählt | toleriert + gezählt/sichtbar |
+
+## 6. Recon-Abschluss & nächster Gate
+
+Der Recon (RECON_01–04) ist **abgeschlossen**: die vier Schluck-Schichten, der None-Konsum,
+die adversariale Bestätigung mit Befund-Umkehrung, und Persistenz/externe Klasse sind
+belegt. Es gibt **keinen** offenen Recon-Punkt mehr, der vor der Spec zwingend ist.
+
+**Nächster Gate = eigene Feature-Spec** (Format wie Context Bridge: Zweck, gepinnter
+Ist-Zustand, Scope/Non-Scope, Zielarchitektur am Andockpunkt `vedana`/`health_anomaly` +
+persistierter Kollaps-Zähler, Testvertrag, LOGGING-vor-Erzwingen, Rollback). **Kein
+Produktcode und keine Feature-Spec ohne ausdrückliches Operator-Go.**


### PR DESCRIPTION
## Summary

This PR documents a complete reconnaissance of the heartbeat failure propagation problem: the Steward heartbeat run is structurally unable to signal failure (red) when cognitive or provider failures occur, despite having rich internal error detection. Four independent `try/except` layers swallow all errors and exit with status 0, making the green signal meaningless as a health indicator.

The PR adds:
1. **Four reconnaissance documents** (RECON_01–04) that forensically trace error handling through the production heartbeat execution path
2. **A master system specification** that frames the problem, establishes non-negotiable constraints, and indexes the evidence
3. **A draft feature specification** that proposes a minimal, observable fix using existing infrastructure

**Status:** Reconnaissance complete. No code changes. Feature spec is DRAFT 0.1 and explicitly locked against implementation until adversarial review and operator approval.

## Key Changes

- **`HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md`** — Master spec establishing the problem (grüner Heartbeat = wertlos), constraints (LOGGING before enforcement, federation resilience), and evidence index
  
- **`heartbeat_failure_propagation_evidence/RECON_01_SWALLOW_PATHS.md`** — Traces four error-swallowing layers (L1: provider cascade returns None; L2: hook dispatch logs and continues; L3a: workflow harness catches and exits 0; L3b: internal phase dispatcher logs at debug level). Establishes that the run is structurally incapable of signaling failure.

- **`heartbeat_failure_propagation_evidence/RECON_02_CONSUMPTION_AND_CLASSES.md`** — Follows the None return value from the cascade into `engine.py` where it surfaces as an `EventType.ERROR` event (visible but not wired to exit status). Identifies existing transient/non-transient classification in `chamber.py` and locates the natural critical boundary (total cascade exhaustion, not single-provider failure). Finds the existing `health_anomaly` flag as a reusable attachment point.

- **`heartbeat_failure_propagation_evidence/RECON_03_ADVERSARIAL.md`** — Attempts to disprove the core claim and instead **inverts the finding**: the problem is not missing detection (detection is overbuilt in `vedana.py` provider-pulse → `dharma.py` health_anomaly), but missing **external wiring**. All signals point inward or are orphaned. Corrects the fix direction: don't naively raise; instead, surface the existing detection at persistent, observable boundaries.

- **`heartbeat_failure_propagation_evidence/RECON_04_PERSISTENCE_AND_EXTERNAL.md`** — Closes remaining gaps: provider/cognitive health state is in-memory only (blind across runs); external/post-action class (git push) is swallowed and uncounted. Delivers consolidated error-class matrix (transient, sustained-in-run, sustained-across-runs, external) ready for feature spec.

- **`HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`** — Draft feature spec proposing three implementation slices (A: visibility via persistent counter + health-report field; B: escalation via existing `dharma` issue pattern; C: optional kill-switch-guarded run signaling). Explicitly locked: no G1 gate, no implementation, no activation without operator approval. Includes adversarial open questions (§10) that must be answered before code.

## Notable Implementation Details

- **No code changes.** All documents are read-only reconnaissance and specification.
- **Isolation:** All new files live in `specs/` and `specs/heartbeat_failure_propagation_evidence/` to avoid merge conflicts with parallel agents.
- **Constraints honored:** LOGGING-before-enforcement (Phase-1 §220), federation resilience (no naive raise), code-only verification (no CLAUDE.md), production-log proof required.
- **Recon methodology:** Verbatim code quotes, adversarial attack (RECON_03), grep-before-build (existing `health_anomaly`, `dharma` issue pattern, `chamber.stats()`).

https://claude.ai/code/session_01MSHenN8BjubGZe2VUghbyR