### PR TITLE
feat(context): add read-only D2a generation observer

### DIFF
--- a/steward/context_contract.py
+++ b/steward/context_contract.py
@@ -1191,6 +1191,13 @@ def _validate_attestation(attestation: ConstitutionAttestation) -> None:
     _validate_hash(attestation.reviewed_at_commit, 40, field_path="constitution_attestation.reviewed_at_commit")
 
 
+def validate_constitution_attestation(attestation: ConstitutionAttestation) -> None:
+    """Validate an external Constitution attestation without inferring its origin."""
+    if type(attestation) is not ConstitutionAttestation:
+        _fail("invalid_type", "constitution_attestation")
+    _validate_attestation(attestation)
+
+
 def validate_previous_published_record(previous: PreviousPublishedRecord) -> None:
     """Validate a materialized published-record value object without attesting its origin."""
     if type(previous) is not PreviousPublishedRecord:

--- a/steward/context_publisher.py
+++ b/steward/context_publisher.py
@@ -258,10 +258,11 @@ def _git_layout_fingerprint(root_fd: int, git_fd: int) -> tuple[tuple[int, ...],
     return tuple(fingerprint)
 
 
-def _target_parent_fingerprint(steward_fd: int | None) -> tuple[tuple[int, ...], ...]:
-    if steward_fd is None:
-        return ()
-    return (_layout_stat_key(os.fstat(steward_fd)),)
+def _target_parent_fingerprint(root_fd: int, steward_fd: int | None) -> tuple[tuple[int, ...], ...]:
+    fingerprint = [_layout_stat_key(os.fstat(root_fd))]
+    if steward_fd is not None:
+        fingerprint.append(_layout_stat_key(os.fstat(steward_fd)))
+    return tuple(fingerprint)
 
 
 def _bounded_process(
@@ -632,14 +633,12 @@ def inspect_repository_generation(
         git_fd = os.open(".git", _OPEN_DIRECTORY, dir_fd=root_fd)
         layout_fingerprint = _git_layout_fingerprint(root_fd, git_fd)
         steward_fd = _optional_directory(root_fd, ".steward")
-        parent_fingerprint = _target_parent_fingerprint(steward_fd)
+        parent_fingerprint = _target_parent_fingerprint(root_fd, steward_fd)
         head, tree, index, head_blobs = _read_git_evidence(git, git_fd, deadline)
         if _git_layout_fingerprint(root_fd, git_fd) != layout_fingerprint:
             return _manual(repository_root, "git_layout_changed", head=head, race=True)
         worktree = _read_worktree(root_fd, steward_fd)
         publisher_signal, ambiguous_signal = _scan_signals(root_fd, steward_fd)
-        if _target_parent_fingerprint(steward_fd) != parent_fingerprint:
-            return _manual(repository_root, "target_parent_changed", head=head, race=True)
         if _git_layout_fingerprint(root_fd, git_fd) != layout_fingerprint:
             return _manual(repository_root, "git_layout_changed", head=head, race=True)
         second_head, second_tree, second_index, second_head_blobs = _read_git_evidence(git, git_fd, deadline)
@@ -647,7 +646,7 @@ def inspect_repository_generation(
             return _manual(repository_root, "git_layout_changed", head=head, race=True)
         second_worktree = _read_worktree(root_fd, steward_fd)
         second_signals = _scan_signals(root_fd, steward_fd)
-        if _target_parent_fingerprint(steward_fd) != parent_fingerprint:
+        if _target_parent_fingerprint(root_fd, steward_fd) != parent_fingerprint:
             return _manual(repository_root, "target_parent_changed", head=head, race=True)
         if _git_layout_fingerprint(root_fd, git_fd) != layout_fingerprint:
             return _manual(repository_root, "git_layout_changed", head=head, race=True)

--- a/steward/context_publisher.py
+++ b/steward/context_publisher.py
@@ -1,0 +1,621 @@
+"""Read-only repository observation for Context Bridge generations."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import re
+import selectors
+import signal
+import stat
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Mapping
+
+from steward.context_contract import ConstitutionAttestation, ContractViolation, PreviousPublishedRecord
+from steward.context_rendering import (
+    PERSISTED_TARGET_MAX_BYTES,
+    PublicationCandidates,
+    validate_constitution_bound_persisted_generation,
+    validate_persisted_generation,
+)
+
+_TARGETS = tuple(PERSISTED_TARGET_MAX_BYTES)
+_ROOT_TARGETS = frozenset({"CLAUDE.md", "AGENTS.md"})
+_HEX40 = re.compile(rb"[0-9a-f]{40}")
+_TRANSACTION = re.compile(r"\.context-publish-v1\.[0-9a-f]{32}\.txn")
+_ROOT_TEMP = re.compile(r"\.context-publish-v1\.[0-9a-f]{32}\.(?:claude|agents)\.tmp")
+_STEWARD_TEMP = re.compile(r"\.context-publish-v1\.[0-9a-f]{32}\.(?:snapshot|publication)\.tmp")
+_LOCK = ".context-publish-v1.lock"
+_CHILD_ENV = {
+    "LC_ALL": "C",
+    "LANG": "C",
+    "PATH": "/usr/bin:/bin",
+    "GIT_OPTIONAL_LOCKS": "0",
+    "GIT_NO_REPLACE_OBJECTS": "1",
+    "GIT_PAGER": "cat",
+    "GIT_CONFIG_NOSYSTEM": "1",
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+}
+_DARWIN_HELPER = (
+    "import os,stat,sys;"
+    "fd=int(sys.argv[1]);dev=int(sys.argv[2]);ino=int(sys.argv[3]);s=os.fstat(fd);"
+    "sys.exit(70) if (s.st_dev!=dev or s.st_ino!=ino or not stat.S_ISDIR(s.st_mode)) else None;"
+    "os.fchdir(fd);git=sys.argv[4];os.execve(git,[git,'--git-dir=.',*sys.argv[5:]],dict(os.environ))"
+)
+_OPEN_DIRECTORY = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW
+_OPEN_FILE = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW
+
+
+class GenerationState(str, Enum):
+    LEGACY_BOOTSTRAP = "legacy_bootstrap"
+    ABSENT = "absent"
+    VALID = "valid"
+    UNATTESTED = "unattested"
+    UNBOUND = "unbound"
+    MIXED = "mixed"
+    INVALID = "invalid"
+    MANUAL_REVIEW = "manual_review"
+
+
+@dataclass(frozen=True)
+class TargetEvidence:
+    head_present: bool
+    head_mode: str | None = None
+    head_blob: str | None = None
+    index_present: bool = False
+    index_mode: str | None = None
+    index_blob: str | None = None
+    worktree_present: bool = False
+    worktree_mode: str | None = None
+    worktree_sha256: str | None = None
+
+
+@dataclass(frozen=True)
+class RepositoryGenerationObservation:
+    state: GenerationState
+    reason: str
+    repository_root: Path
+    head: str | None
+    targets: Mapping[str, TargetEvidence]
+    previous: PreviousPublishedRecord | None = None
+    publisher_signal: bool = False
+    race_detected: bool = False
+
+
+@dataclass(frozen=True)
+class _GitTarget:
+    mode: str
+    blob: str
+
+
+@dataclass(frozen=True)
+class _WorktreeTarget:
+    data: bytes
+    sha256: str
+    stat_key: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _RepositoryEvidence:
+    head: str
+    tree: Mapping[str, _GitTarget]
+    index: Mapping[str, _GitTarget]
+    head_blobs: Mapping[str, bytes]
+    worktree: Mapping[str, _WorktreeTarget | None]
+    publisher_signal: bool
+    multiple_or_unknown_signal: bool
+
+
+class _ObservationFailure(Exception):
+    pass
+
+
+def _safe_executable(candidates: tuple[str, ...]) -> tuple[str, tuple[int, ...]]:
+    for candidate in candidates:
+        try:
+            current = Path("/")
+            for component in Path(candidate).parts[1:]:
+                current /= component
+                value = os.lstat(current)
+                if stat.S_ISLNK(value.st_mode) or value.st_uid != 0 or value.st_mode & 0o022:
+                    raise _ObservationFailure
+                if component == Path(candidate).name:
+                    if not stat.S_ISREG(value.st_mode):
+                        raise _ObservationFailure
+                elif not stat.S_ISDIR(value.st_mode):
+                    raise _ObservationFailure
+            value = os.lstat(candidate)
+            return candidate, _stat_identity(value)
+        except (OSError, _ObservationFailure):
+            continue
+    raise _ObservationFailure
+
+
+def _stat_identity(value: os.stat_result) -> tuple[int, ...]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        stat.S_IFMT(value.st_mode),
+        value.st_uid,
+        stat.S_IMODE(value.st_mode),
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _file_stat_key(value: os.stat_result) -> tuple[int, ...]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        stat.S_IFMT(value.st_mode),
+        value.st_nlink,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _open_repository_root(repository_root: Path) -> int:
+    if not isinstance(repository_root, Path) or not repository_root.is_absolute():
+        raise _ObservationFailure
+    lexical = os.path.normpath(os.fspath(repository_root))
+    if lexical != os.fspath(repository_root):
+        raise _ObservationFailure
+    descriptor = os.open("/", _OPEN_DIRECTORY)
+    try:
+        for component in repository_root.parts[1:]:
+            if component in {"", ".", ".."}:
+                raise _ObservationFailure
+            child = os.open(component, _OPEN_DIRECTORY, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except (OSError, _ObservationFailure):
+        os.close(descriptor)
+        raise _ObservationFailure
+
+
+def _optional_directory(parent_fd: int, name: str) -> int | None:
+    try:
+        return os.open(name, _OPEN_DIRECTORY, dir_fd=parent_fd)
+    except FileNotFoundError:
+        return None
+    except OSError as error:
+        if error.errno == errno.ENOENT:
+            return None
+        raise _ObservationFailure from None
+
+
+def _reject_unsupported_git_layout(root_fd: int, git_fd: int) -> None:
+    root_git = os.stat(".git", dir_fd=root_fd, follow_symlinks=False)
+    opened_git = os.fstat(git_fd)
+    if not stat.S_ISDIR(root_git.st_mode) or (root_git.st_dev, root_git.st_ino) != (
+        opened_git.st_dev,
+        opened_git.st_ino,
+    ):
+        raise _ObservationFailure
+    for relative in ("commondir", "gitdir"):
+        try:
+            os.stat(relative, dir_fd=git_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise _ObservationFailure
+    objects_fd = _optional_directory(git_fd, "objects")
+    if objects_fd is None:
+        raise _ObservationFailure
+    try:
+        info_fd = _optional_directory(objects_fd, "info")
+        if info_fd is not None:
+            try:
+                try:
+                    os.stat("alternates", dir_fd=info_fd, follow_symlinks=False)
+                except FileNotFoundError:
+                    pass
+                else:
+                    raise _ObservationFailure
+            finally:
+                os.close(info_fd)
+    finally:
+        os.close(objects_fd)
+
+
+def _bounded_process(
+    arguments: list[str],
+    *,
+    pass_fd: int,
+    stdout_limit: int,
+    deadline: float,
+) -> bytes:
+    remaining = min(5.0, deadline - time.monotonic())
+    if remaining <= 0:
+        raise _ObservationFailure
+    process = subprocess.Popen(
+        arguments,
+        cwd="/",
+        env=_CHILD_ENV,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True,
+        pass_fds=(pass_fd,),
+        start_new_session=True,
+    )
+    assert process.stdout is not None and process.stderr is not None
+    stdout_fd = process.stdout.fileno()
+    streams = {stdout_fd: (process.stdout, stdout_limit), process.stderr.fileno(): (process.stderr, 4096)}
+    output = {descriptor: bytearray() for descriptor in streams}
+    selector = selectors.DefaultSelector()
+    try:
+        for descriptor in streams:
+            os.set_blocking(descriptor, False)
+            selector.register(descriptor, selectors.EVENT_READ)
+        end = time.monotonic() + remaining
+        while selector.get_map():
+            timeout = end - time.monotonic()
+            if timeout <= 0:
+                raise _ObservationFailure
+            events = selector.select(timeout)
+            if not events:
+                raise _ObservationFailure
+            for key, _ in events:
+                descriptor = key.fd
+                chunk = os.read(descriptor, min(8192, streams[descriptor][1] + 1 - len(output[descriptor])))
+                if not chunk:
+                    selector.unregister(descriptor)
+                    continue
+                output[descriptor].extend(chunk)
+                if len(output[descriptor]) > streams[descriptor][1]:
+                    raise _ObservationFailure
+        process.wait(timeout=max(0.01, end - time.monotonic()))
+    except (OSError, subprocess.SubprocessError, _ObservationFailure):
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (OSError, ProcessLookupError):
+            pass
+        process.wait()
+        raise _ObservationFailure from None
+    finally:
+        selector.close()
+        process.stdout.close()
+        process.stderr.close()
+    if process.returncode != 0:
+        raise _ObservationFailure
+    return bytes(output[stdout_fd])
+
+
+def _git_command(
+    git: str,
+    git_fd: int,
+    arguments: list[str],
+    *,
+    stdout_limit: int,
+    deadline: float,
+) -> bytes:
+    git_stat = os.fstat(git_fd)
+    if sys.platform.startswith("linux"):
+        proc_path = f"/proc/self/fd/{git_fd}"
+        proc_stat = os.stat(proc_path)
+        if (proc_stat.st_dev, proc_stat.st_ino) != (git_stat.st_dev, git_stat.st_ino):
+            raise _ObservationFailure
+        command = [git, f"--git-dir={proc_path}", *arguments]
+    elif sys.platform == "darwin":
+        python, _ = _safe_executable(("/usr/bin/python3",))
+        command = [
+            python,
+            "-I",
+            "-S",
+            "-c",
+            _DARWIN_HELPER,
+            str(git_fd),
+            str(git_stat.st_dev),
+            str(git_stat.st_ino),
+            git,
+            *arguments,
+        ]
+    else:
+        raise _ObservationFailure
+    return _bounded_process(command, pass_fd=git_fd, stdout_limit=stdout_limit, deadline=deadline)
+
+
+def _parse_head(value: bytes) -> str:
+    stripped = value.rstrip(b"\n")
+    if not _HEX40.fullmatch(stripped) or value not in {stripped, stripped + b"\n"}:
+        raise _ObservationFailure
+    return stripped.decode("ascii")
+
+
+def _parse_tree(value: bytes) -> Mapping[str, _GitTarget]:
+    result: dict[str, _GitTarget] = {}
+    for record in value.split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata, raw_path = record.split(b"\t", 1)
+            mode, kind, blob = metadata.split(b" ")
+            path = raw_path.decode("utf-8")
+        except (UnicodeDecodeError, ValueError):
+            raise _ObservationFailure from None
+        if path not in _TARGETS or path in result or kind != b"blob" or mode != b"100644" or not _HEX40.fullmatch(blob):
+            raise _ObservationFailure
+        result[path] = _GitTarget(mode.decode("ascii"), blob.decode("ascii"))
+    return MappingProxyType(result)
+
+
+def _parse_index(value: bytes) -> Mapping[str, _GitTarget]:
+    result: dict[str, _GitTarget] = {}
+    for record in value.split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata, raw_path = record.split(b"\t", 1)
+            mode, blob, stage = metadata.split(b" ")
+            path = raw_path.decode("utf-8")
+        except (UnicodeDecodeError, ValueError):
+            raise _ObservationFailure from None
+        if path not in _TARGETS or path in result or stage != b"0" or mode != b"100644" or not _HEX40.fullmatch(blob):
+            raise _ObservationFailure
+        result[path] = _GitTarget(mode.decode("ascii"), blob.decode("ascii"))
+    return MappingProxyType(result)
+
+
+def _read_git_evidence(
+    git: str, git_fd: int, deadline: float
+) -> tuple[str, Mapping[str, _GitTarget], Mapping[str, _GitTarget], Mapping[str, bytes]]:
+    pathspec = ["--", *_TARGETS]
+    head = _parse_head(
+        _git_command(git, git_fd, ["rev-parse", "--verify", "HEAD"], stdout_limit=4096, deadline=deadline)
+    )
+    tree = _parse_tree(
+        _git_command(git, git_fd, ["ls-tree", "-rz", head, *pathspec], stdout_limit=16384, deadline=deadline)
+    )
+    index = _parse_index(
+        _git_command(git, git_fd, ["ls-files", "--stage", "-z", *pathspec], stdout_limit=16384, deadline=deadline)
+    )
+    head_blobs = {
+        path: _git_command(
+            git,
+            git_fd,
+            ["cat-file", "blob", target.blob],
+            stdout_limit=PERSISTED_TARGET_MAX_BYTES[path] + 1,
+            deadline=deadline,
+        )
+        for path, target in tree.items()
+    }
+    return head, tree, index, MappingProxyType(head_blobs)
+
+
+def _read_target(parent_fd: int, name: str, limit: int) -> _WorktreeTarget | None:
+    try:
+        lstat_value = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return None
+    if not stat.S_ISREG(lstat_value.st_mode) or lstat_value.st_nlink != 1 or lstat_value.st_size > limit:
+        raise _ObservationFailure
+    try:
+        descriptor = os.open(name, _OPEN_FILE, dir_fd=parent_fd)
+    except OSError:
+        raise _ObservationFailure from None
+    try:
+        before = os.fstat(descriptor)
+        if _file_stat_key(before) != _file_stat_key(lstat_value):
+            raise _ObservationFailure
+        data = bytearray()
+        while len(data) <= limit:
+            chunk = os.read(descriptor, min(8192, limit + 1 - len(data)))
+            if not chunk:
+                break
+            data.extend(chunk)
+        if len(data) != before.st_size or len(data) > limit or os.read(descriptor, 1):
+            raise _ObservationFailure
+        after = os.fstat(descriptor)
+        final_lstat = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+        key = _file_stat_key(before)
+        if _file_stat_key(after) != key or _file_stat_key(final_lstat) != key:
+            raise _ObservationFailure
+        raw = bytes(data)
+        return _WorktreeTarget(raw, hashlib.sha256(raw).hexdigest(), key)
+    finally:
+        os.close(descriptor)
+
+
+def _read_worktree(root_fd: int, steward_fd: int | None) -> Mapping[str, _WorktreeTarget | None]:
+    result: dict[str, _WorktreeTarget | None] = {}
+    for path, limit in PERSISTED_TARGET_MAX_BYTES.items():
+        if path in _ROOT_TARGETS:
+            result[path] = _read_target(root_fd, path, limit)
+        elif steward_fd is None:
+            result[path] = None
+        else:
+            result[path] = _read_target(steward_fd, path.removeprefix(".steward/"), limit)
+    return MappingProxyType(result)
+
+
+def _scan_signals(root_fd: int, steward_fd: int | None) -> tuple[bool, bool]:
+    exact = 0
+    unknown = False
+    for name in os.listdir(root_fd):
+        if _ROOT_TEMP.fullmatch(name):
+            exact += 1
+        elif name.startswith(".context-publish-"):
+            unknown = True
+    if steward_fd is not None:
+        for name in os.listdir(steward_fd):
+            if name == _LOCK:
+                unknown = True
+            elif _TRANSACTION.fullmatch(name) or _STEWARD_TEMP.fullmatch(name):
+                exact += 1
+            elif name.startswith(".context-publish-"):
+                unknown = True
+    return exact == 1, unknown or exact > 1
+
+
+def _target_evidence(evidence: _RepositoryEvidence) -> Mapping[str, TargetEvidence]:
+    result: dict[str, TargetEvidence] = {}
+    for path in _TARGETS:
+        head = evidence.tree.get(path)
+        index = evidence.index.get(path)
+        worktree = evidence.worktree[path]
+        result[path] = TargetEvidence(
+            head_present=head is not None,
+            head_mode=head.mode if head else None,
+            head_blob=head.blob if head else None,
+            index_present=index is not None,
+            index_mode=index.mode if index else None,
+            index_blob=index.blob if index else None,
+            worktree_present=worktree is not None,
+            worktree_mode="100644" if worktree else None,
+            worktree_sha256=worktree.sha256 if worktree else None,
+        )
+    return MappingProxyType(result)
+
+
+def _candidates(worktree: Mapping[str, _WorktreeTarget | None]) -> PublicationCandidates:
+    if any(worktree[path] is None for path in _TARGETS):
+        raise _ObservationFailure
+    return PublicationCandidates(
+        claude_md=worktree["CLAUDE.md"].data,  # type: ignore[union-attr]
+        agents_md=worktree["AGENTS.md"].data,  # type: ignore[union-attr]
+        snapshot_artifact=worktree[".steward/context-snapshot.json"].data,  # type: ignore[union-attr]
+        publication_artifact=worktree[".steward/context-publication.json"].data,  # type: ignore[union-attr]
+    )
+
+
+def _head_bound(evidence: _RepositoryEvidence) -> bool:
+    for path in _TARGETS:
+        if not _path_head_bound(evidence, path):
+            return False
+    return True
+
+
+def _path_head_bound(
+    evidence: _RepositoryEvidence,
+    path: str,
+) -> bool:
+    target = evidence.tree.get(path)
+    worktree = evidence.worktree[path]
+    if target is None or worktree is None:
+        return False
+    return evidence.head_blobs.get(path) == worktree.data
+
+
+def _classify(
+    evidence: _RepositoryEvidence,
+    attestation: ConstitutionAttestation,
+) -> tuple[GenerationState, str, PreviousPublishedRecord | None]:
+    if evidence.multiple_or_unknown_signal:
+        return GenerationState.MANUAL_REVIEW, "publisher_signal_ambiguous", None
+    if evidence.tree != evidence.index:
+        return GenerationState.MANUAL_REVIEW, "index_differs_from_head", None
+    present = {path for path, value in evidence.worktree.items() if value is not None}
+    if evidence.publisher_signal and len(present) < len(_TARGETS):
+        return GenerationState.MIXED, "transaction_partial_generation", None
+    if len(present) == len(_TARGETS):
+        candidates = _candidates(evidence.worktree)
+        try:
+            validate_persisted_generation(candidates)
+        except ContractViolation:
+            return GenerationState.INVALID, "generation_contract_invalid", None
+        if not _head_bound(evidence):
+            return GenerationState.UNBOUND, "generation_not_head_bound", None
+        try:
+            previous = validate_constitution_bound_persisted_generation(candidates, attestation)
+        except ContractViolation:
+            return GenerationState.UNATTESTED, "constitution_not_attested", None
+        return GenerationState.VALID, "head_bound_generation_valid", previous
+    generated = evidence.publisher_signal or any(
+        path not in _ROOT_TARGETS or b"<!-- steward-context:" in evidence.worktree[path].data for path in present
+    )
+    if generated:
+        return GenerationState.MIXED, "partial_generated_state", None
+    if not present and not evidence.tree and not evidence.index:
+        return GenerationState.ABSENT, "all_targets_absent", None
+    legacy = {"CLAUDE.md"}
+    if present == legacy and set(evidence.tree) == legacy and set(evidence.index) == legacy:
+        if _path_head_bound(evidence, "CLAUDE.md"):
+            return GenerationState.LEGACY_BOOTSTRAP, "legacy_claude_only", None
+    return GenerationState.MANUAL_REVIEW, "state_not_safely_classified", None
+
+
+def _manual(
+    repository_root: Path, reason: str, *, head: str | None = None, race: bool = False
+) -> RepositoryGenerationObservation:
+    return RepositoryGenerationObservation(
+        state=GenerationState.MANUAL_REVIEW,
+        reason=reason,
+        repository_root=repository_root,
+        head=head,
+        targets=MappingProxyType({}),
+        race_detected=race,
+    )
+
+
+def inspect_repository_generation(
+    repository_root: Path,
+    attestation: ConstitutionAttestation,
+) -> RepositoryGenerationObservation:
+    """Observe and classify the four fixed V1 targets without mutating the repository."""
+    deadline = time.monotonic() + 20.0
+    root_fd: int | None = None
+    git_fd: int | None = None
+    steward_fd: int | None = None
+    head: str | None = None
+    try:
+        git, git_identity = _safe_executable(("/usr/bin/git", "/bin/git"))
+        root_fd = _open_repository_root(repository_root)
+        git_fd = os.open(".git", _OPEN_DIRECTORY, dir_fd=root_fd)
+        _reject_unsupported_git_layout(root_fd, git_fd)
+        steward_fd = _optional_directory(root_fd, ".steward")
+        head, tree, index, head_blobs = _read_git_evidence(git, git_fd, deadline)
+        worktree = _read_worktree(root_fd, steward_fd)
+        publisher_signal, ambiguous_signal = _scan_signals(root_fd, steward_fd)
+        second_head, second_tree, second_index, second_head_blobs = _read_git_evidence(git, git_fd, deadline)
+        second_worktree = _read_worktree(root_fd, steward_fd)
+        second_signals = _scan_signals(root_fd, steward_fd)
+        if (head, tree, index, head_blobs, worktree, publisher_signal, ambiguous_signal) != (
+            second_head,
+            second_tree,
+            second_index,
+            second_head_blobs,
+            second_worktree,
+            *second_signals,
+        ):
+            return _manual(repository_root, "repository_changed_during_observation", head=head, race=True)
+        if _safe_executable((git,))[1] != git_identity:
+            return _manual(repository_root, "git_executable_changed", head=head, race=True)
+        evidence = _RepositoryEvidence(
+            head=head,
+            tree=tree,
+            index=index,
+            head_blobs=head_blobs,
+            worktree=worktree,
+            publisher_signal=publisher_signal,
+            multiple_or_unknown_signal=ambiguous_signal,
+        )
+        state, reason, previous = _classify(evidence, attestation)
+        return RepositoryGenerationObservation(
+            state=state,
+            reason=reason,
+            repository_root=repository_root,
+            head=head,
+            targets=_target_evidence(evidence),
+            previous=previous,
+            publisher_signal=publisher_signal,
+        )
+    except (ContractViolation, OSError, ValueError, _ObservationFailure):
+        return _manual(repository_root, "repository_observation_failed", head=head)
+    finally:
+        if steward_fd is not None:
+            os.close(steward_fd)
+        if git_fd is not None:
+            os.close(git_fd)
+        if root_fd is not None:
+            os.close(root_fd)

--- a/steward/context_publisher.py
+++ b/steward/context_publisher.py
@@ -100,6 +100,7 @@ class _GitTarget:
 class _WorktreeTarget:
     data: bytes
     sha256: str
+    mode: str
     stat_key: tuple[int, ...]
 
 
@@ -194,12 +195,26 @@ def _optional_directory(parent_fd: int, name: str) -> int | None:
         raise _ObservationFailure from None
 
 
-def _reject_unsupported_git_layout(root_fd: int, git_fd: int) -> None:
+def _layout_stat_key(value: os.stat_result) -> tuple[int, ...]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        stat.S_IFMT(value.st_mode),
+        value.st_nlink,
+        value.st_uid,
+        stat.S_IMODE(value.st_mode),
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _git_layout_fingerprint(root_fd: int, git_fd: int) -> tuple[tuple[int, ...], ...]:
     root_git = os.stat(".git", dir_fd=root_fd, follow_symlinks=False)
-    opened_git = os.fstat(git_fd)
+    opened_git_before = os.fstat(git_fd)
     if not stat.S_ISDIR(root_git.st_mode) or (root_git.st_dev, root_git.st_ino) != (
-        opened_git.st_dev,
-        opened_git.st_ino,
+        opened_git_before.st_dev,
+        opened_git_before.st_ino,
     ):
         raise _ObservationFailure
     for relative in ("commondir", "gitdir"):
@@ -209,23 +224,38 @@ def _reject_unsupported_git_layout(root_fd: int, git_fd: int) -> None:
             pass
         else:
             raise _ObservationFailure
+    opened_git_after = os.fstat(git_fd)
+    if _layout_stat_key(opened_git_before) != _layout_stat_key(opened_git_after):
+        raise _ObservationFailure
     objects_fd = _optional_directory(git_fd, "objects")
     if objects_fd is None:
         raise _ObservationFailure
     try:
+        objects_before = os.fstat(objects_fd)
         info_fd = _optional_directory(objects_fd, "info")
         if info_fd is not None:
             try:
+                info_before = os.fstat(info_fd)
                 try:
                     os.stat("alternates", dir_fd=info_fd, follow_symlinks=False)
                 except FileNotFoundError:
                     pass
                 else:
                     raise _ObservationFailure
+                info_after = os.fstat(info_fd)
+                if _layout_stat_key(info_before) != _layout_stat_key(info_after):
+                    raise _ObservationFailure
             finally:
                 os.close(info_fd)
+        objects_after = os.fstat(objects_fd)
+        if _layout_stat_key(objects_before) != _layout_stat_key(objects_after):
+            raise _ObservationFailure
     finally:
         os.close(objects_fd)
+    fingerprint = [_layout_stat_key(opened_git_after), _layout_stat_key(objects_after)]
+    if info_fd is not None:
+        fingerprint.append(_layout_stat_key(info_after))
+    return tuple(fingerprint)
 
 
 def _bounded_process(
@@ -238,17 +268,21 @@ def _bounded_process(
     remaining = min(5.0, deadline - time.monotonic())
     if remaining <= 0:
         raise _ObservationFailure
-    process = subprocess.Popen(
-        arguments,
-        cwd="/",
-        env=_CHILD_ENV,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        close_fds=True,
-        pass_fds=(pass_fd,),
-        start_new_session=True,
-    )
+    null_fd = os.open(os.devnull, os.O_RDONLY | os.O_CLOEXEC)
+    try:
+        process = subprocess.Popen(
+            arguments,
+            cwd="/",
+            env=_CHILD_ENV,
+            stdin=null_fd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            close_fds=True,
+            pass_fds=(pass_fd,),
+            start_new_session=True,
+        )
+    finally:
+        os.close(null_fd)
     assert process.stdout is not None and process.stderr is not None
     stdout_fd = process.stdout.fileno()
     streams = {stdout_fd: (process.stdout, stdout_limit), process.stderr.fileno(): (process.stderr, 4096)}
@@ -335,9 +369,7 @@ def _parse_head(value: bytes) -> str:
 
 def _parse_tree(value: bytes) -> Mapping[str, _GitTarget]:
     result: dict[str, _GitTarget] = {}
-    for record in value.split(b"\0"):
-        if not record:
-            continue
+    for record in _nul_records(value):
         try:
             metadata, raw_path = record.split(b"\t", 1)
             mode, kind, blob = metadata.split(b" ")
@@ -352,9 +384,7 @@ def _parse_tree(value: bytes) -> Mapping[str, _GitTarget]:
 
 def _parse_index(value: bytes) -> Mapping[str, _GitTarget]:
     result: dict[str, _GitTarget] = {}
-    for record in value.split(b"\0"):
-        if not record:
-            continue
+    for record in _nul_records(value):
         try:
             metadata, raw_path = record.split(b"\t", 1)
             mode, blob, stage = metadata.split(b" ")
@@ -367,13 +397,29 @@ def _parse_index(value: bytes) -> Mapping[str, _GitTarget]:
     return MappingProxyType(result)
 
 
+def _nul_records(value: bytes) -> tuple[bytes, ...]:
+    if not value:
+        return ()
+    if not value.endswith(b"\0") or b"\0\0" in value:
+        raise _ObservationFailure
+    records = tuple(value[:-1].split(b"\0"))
+    if any(not record for record in records):
+        raise _ObservationFailure
+    return records
+
+
 def _read_git_evidence(
     git: str, git_fd: int, deadline: float
 ) -> tuple[str, Mapping[str, _GitTarget], Mapping[str, _GitTarget], Mapping[str, bytes]]:
     pathspec = ["--", *_TARGETS]
-    head = _parse_head(
+    raw_head = _parse_head(
         _git_command(git, git_fd, ["rev-parse", "--verify", "HEAD"], stdout_limit=4096, deadline=deadline)
     )
+    head = _parse_head(
+        _git_command(git, git_fd, ["rev-parse", "--verify", "HEAD^{commit}"], stdout_limit=4096, deadline=deadline)
+    )
+    if raw_head != head:
+        raise _ObservationFailure
     tree = _parse_tree(
         _git_command(git, git_fd, ["ls-tree", "-rz", head, *pathspec], stdout_limit=16384, deadline=deadline)
     )
@@ -422,7 +468,7 @@ def _read_target(parent_fd: int, name: str, limit: int) -> _WorktreeTarget | Non
         if _file_stat_key(after) != key or _file_stat_key(final_lstat) != key:
             raise _ObservationFailure
         raw = bytes(data)
-        return _WorktreeTarget(raw, hashlib.sha256(raw).hexdigest(), key)
+        return _WorktreeTarget(raw, hashlib.sha256(raw).hexdigest(), f"{before.st_mode:o}", key)
     finally:
         os.close(descriptor)
 
@@ -472,7 +518,7 @@ def _target_evidence(evidence: _RepositoryEvidence) -> Mapping[str, TargetEviden
             index_mode=index.mode if index else None,
             index_blob=index.blob if index else None,
             worktree_present=worktree is not None,
-            worktree_mode="100644" if worktree else None,
+            worktree_mode=worktree.mode if worktree else None,
             worktree_sha256=worktree.sha256 if worktree else None,
         )
     return MappingProxyType(result)
@@ -516,8 +562,8 @@ def _classify(
     if evidence.tree != evidence.index:
         return GenerationState.MANUAL_REVIEW, "index_differs_from_head", None
     present = {path for path, value in evidence.worktree.items() if value is not None}
-    if evidence.publisher_signal and len(present) < len(_TARGETS):
-        return GenerationState.MIXED, "transaction_partial_generation", None
+    if evidence.publisher_signal:
+        return GenerationState.MIXED, "transaction_generation_present", None
     if len(present) == len(_TARGETS):
         candidates = _candidates(evidence.worktree)
         try:
@@ -572,14 +618,22 @@ def inspect_repository_generation(
         git, git_identity = _safe_executable(("/usr/bin/git", "/bin/git"))
         root_fd = _open_repository_root(repository_root)
         git_fd = os.open(".git", _OPEN_DIRECTORY, dir_fd=root_fd)
-        _reject_unsupported_git_layout(root_fd, git_fd)
+        layout_fingerprint = _git_layout_fingerprint(root_fd, git_fd)
         steward_fd = _optional_directory(root_fd, ".steward")
         head, tree, index, head_blobs = _read_git_evidence(git, git_fd, deadline)
+        if _git_layout_fingerprint(root_fd, git_fd) != layout_fingerprint:
+            return _manual(repository_root, "git_layout_changed", head=head, race=True)
         worktree = _read_worktree(root_fd, steward_fd)
         publisher_signal, ambiguous_signal = _scan_signals(root_fd, steward_fd)
+        if _git_layout_fingerprint(root_fd, git_fd) != layout_fingerprint:
+            return _manual(repository_root, "git_layout_changed", head=head, race=True)
         second_head, second_tree, second_index, second_head_blobs = _read_git_evidence(git, git_fd, deadline)
+        if _git_layout_fingerprint(root_fd, git_fd) != layout_fingerprint:
+            return _manual(repository_root, "git_layout_changed", head=head, race=True)
         second_worktree = _read_worktree(root_fd, steward_fd)
         second_signals = _scan_signals(root_fd, steward_fd)
+        if _git_layout_fingerprint(root_fd, git_fd) != layout_fingerprint:
+            return _manual(repository_root, "git_layout_changed", head=head, race=True)
         if (head, tree, index, head_blobs, worktree, publisher_signal, ambiguous_signal) != (
             second_head,
             second_tree,

--- a/steward/context_publisher.py
+++ b/steward/context_publisher.py
@@ -258,6 +258,12 @@ def _git_layout_fingerprint(root_fd: int, git_fd: int) -> tuple[tuple[int, ...],
     return tuple(fingerprint)
 
 
+def _target_parent_fingerprint(steward_fd: int | None) -> tuple[tuple[int, ...], ...]:
+    if steward_fd is None:
+        return ()
+    return (_layout_stat_key(os.fstat(steward_fd)),)
+
+
 def _bounded_process(
     arguments: list[str],
     *,
@@ -421,7 +427,13 @@ def _read_git_evidence(
     if raw_head != head:
         raise _ObservationFailure
     tree = _parse_tree(
-        _git_command(git, git_fd, ["ls-tree", "-rz", head, *pathspec], stdout_limit=16384, deadline=deadline)
+        _git_command(
+            git,
+            git_fd,
+            ["ls-tree", "-z", "--full-tree", head, *pathspec],
+            stdout_limit=16384,
+            deadline=deadline,
+        )
     )
     index = _parse_index(
         _git_command(git, git_fd, ["ls-files", "--stage", "-z", *pathspec], stdout_limit=16384, deadline=deadline)
@@ -620,11 +632,14 @@ def inspect_repository_generation(
         git_fd = os.open(".git", _OPEN_DIRECTORY, dir_fd=root_fd)
         layout_fingerprint = _git_layout_fingerprint(root_fd, git_fd)
         steward_fd = _optional_directory(root_fd, ".steward")
+        parent_fingerprint = _target_parent_fingerprint(steward_fd)
         head, tree, index, head_blobs = _read_git_evidence(git, git_fd, deadline)
         if _git_layout_fingerprint(root_fd, git_fd) != layout_fingerprint:
             return _manual(repository_root, "git_layout_changed", head=head, race=True)
         worktree = _read_worktree(root_fd, steward_fd)
         publisher_signal, ambiguous_signal = _scan_signals(root_fd, steward_fd)
+        if _target_parent_fingerprint(steward_fd) != parent_fingerprint:
+            return _manual(repository_root, "target_parent_changed", head=head, race=True)
         if _git_layout_fingerprint(root_fd, git_fd) != layout_fingerprint:
             return _manual(repository_root, "git_layout_changed", head=head, race=True)
         second_head, second_tree, second_index, second_head_blobs = _read_git_evidence(git, git_fd, deadline)
@@ -632,6 +647,8 @@ def inspect_repository_generation(
             return _manual(repository_root, "git_layout_changed", head=head, race=True)
         second_worktree = _read_worktree(root_fd, steward_fd)
         second_signals = _scan_signals(root_fd, steward_fd)
+        if _target_parent_fingerprint(steward_fd) != parent_fingerprint:
+            return _manual(repository_root, "target_parent_changed", head=head, race=True)
         if _git_layout_fingerprint(root_fd, git_fd) != layout_fingerprint:
             return _manual(repository_root, "git_layout_changed", head=head, race=True)
         if (head, tree, index, head_blobs, worktree, publisher_signal, ambiguous_signal) != (

--- a/steward/context_rendering.py
+++ b/steward/context_rendering.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Mapping
 
 from steward.context_contract import (
@@ -12,6 +13,7 @@ from steward.context_contract import (
     C0_END,
     ORIENTATION_BEGIN,
     ORIENTATION_END,
+    ConstitutionAttestation,
     ContractViolation,
     OutputMode,
     PreviousPublishedRecord,
@@ -19,6 +21,7 @@ from steward.context_contract import (
     consumer_output_hash,
     payload_hash,
     snapshot_hash,
+    validate_constitution_attestation,
     validate_payload_core,
     validate_previous_published_record,
     validate_snapshot_model,
@@ -30,6 +33,14 @@ DYNAMIC_END = "<!-- steward-context:dynamic:v1:end -->"
 _ROOT_MAX_BYTES = 65_536
 _SNAPSHOT_MAX_BYTES = 131_072
 _PUBLICATION_MAX_BYTES = 16_384
+PERSISTED_TARGET_MAX_BYTES: Mapping[str, int] = MappingProxyType(
+    {
+        "CLAUDE.md": _ROOT_MAX_BYTES,
+        "AGENTS.md": _ROOT_MAX_BYTES,
+        ".steward/context-snapshot.json": _SNAPSHOT_MAX_BYTES,
+        ".steward/context-publication.json": _PUBLICATION_MAX_BYTES,
+    }
+)
 _SNAPSHOT_SCHEMA = "steward.context.snapshot-artifact/v1"
 _PUBLICATION_SCHEMA = "steward.context.publication-artifact/v1"
 _TARGETS = {
@@ -361,7 +372,10 @@ def validate_publication_candidates(
         _fail("inconsistent", "candidates")
 
 
-def _validate_persisted_generation(candidates: PublicationCandidates) -> PreviousPublishedRecord:
+def _validate_persisted_generation(
+    candidates: PublicationCandidates,
+    attestation: ConstitutionAttestation | None = None,
+) -> PreviousPublishedRecord:
     snapshot_envelope = _exact_mapping(
         _strict_json_bytes(candidates.snapshot_artifact, _SNAPSHOT_MAX_BYTES, "persisted.snapshot_artifact"),
         {"schema", "snapshot_id", "snapshot_hash", "snapshot"},
@@ -448,6 +462,13 @@ def _validate_persisted_generation(candidates: PublicationCandidates) -> Previou
         _fail("inconsistent", "persisted.publication_artifact.constitution.source_blob")
     if constitution["reviewed_at_commit"] != snapshot_constitution["reviewed_at_commit"]:
         _fail("inconsistent", "persisted.publication_artifact.constitution.reviewed_at_commit")
+    if attestation is not None:
+        if attestation.c0_sha256 != snapshot_constitution["sha256"]:
+            _fail("inconsistent", "persisted.constitution_attestation.c0_sha256")
+        if attestation.source_blob != snapshot_constitution["source_blob"]:
+            _fail("inconsistent", "persisted.constitution_attestation.source_blob")
+        if attestation.reviewed_at_commit != snapshot_constitution["reviewed_at_commit"]:
+            _fail("inconsistent", "persisted.constitution_attestation.reviewed_at_commit")
     if previous.snapshot_id != snapshot_id:
         _fail("inconsistent", "persisted.publication_artifact.previous.snapshot_id")
     if previous.c0_sha256 != snapshot_constitution["sha256"]:
@@ -494,6 +515,22 @@ def validate_persisted_generation(candidates: PublicationCandidates) -> Previous
         _fail("invalid_type", "persisted")
     try:
         return _validate_persisted_generation(candidates)
+    except ContractViolation:
+        raise
+    except (AttributeError, IndexError, KeyError, RecursionError, TypeError, UnicodeError, ValueError):
+        _fail("invalid_type", "persisted")
+
+
+def validate_constitution_bound_persisted_generation(
+    candidates: PublicationCandidates,
+    attestation: ConstitutionAttestation,
+) -> PreviousPublishedRecord:
+    """Validate one persisted generation against an external Constitution attestation."""
+    if type(candidates) is not PublicationCandidates:
+        _fail("invalid_type", "persisted")
+    validate_constitution_attestation(attestation)
+    try:
+        return _validate_persisted_generation(candidates, attestation)
     except ContractViolation:
         raise
     except (AttributeError, IndexError, KeyError, RecursionError, TypeError, UnicodeError, ValueError):

--- a/tests/test_context_publisher.py
+++ b/tests/test_context_publisher.py
@@ -1211,6 +1211,42 @@ def test_mutation_after_final_git_reference_is_detected_by_second_read(tmp_path,
     assert observation.race_detected is True
 
 
+def test_root_target_inode_swap_is_detected_by_parent_fingerprint(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    target = repository / "CLAUDE.md"
+    target.write_text("head\n")
+    commit_all(repository)
+    target.write_text("dirty\n")
+    identical = tmp_path / "head-identical"
+    identical.write_text("head\n")
+    displaced = tmp_path / "dirty-original"
+    original_read = context_publisher._read_worktree
+    calls = 0
+
+    def exchange_for_both_reads(root_fd, steward_fd):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            target.rename(displaced)
+            identical.rename(target)
+            result = original_read(root_fd, steward_fd)
+        elif calls == 2:
+            result = original_read(root_fd, steward_fd)
+            target.rename(identical)
+            displaced.rename(target)
+        else:
+            result = original_read(root_fd, steward_fd)
+        return result
+
+    monkeypatch.setattr(context_publisher, "_read_worktree", exchange_for_both_reads)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+    assert observation.race_detected is True
+    assert target.read_text() == "dirty\n"
+
+
 def test_git_and_worktree_remain_bound_after_root_replacement(tmp_path, monkeypatch):
     repository = initialize_repository(tmp_path / "repo")
     (repository / "CLAUDE.md").write_text("original\n")
@@ -1271,7 +1307,8 @@ def test_git_and_worktree_remain_bound_after_root_replacement(tmp_path, monkeypa
 
     observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
 
-    assert observation.state is GenerationState.LEGACY_BOOTSTRAP
+    assert observation.state is GenerationState.MANUAL_REVIEW
+    assert observation.race_detected is True
     assert observation.head == original_head
     assert captured_tree == [original_tree, original_tree]
     assert captured_index == [original_index, original_index]

--- a/tests/test_context_publisher.py
+++ b/tests/test_context_publisher.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+import builtins
+import fcntl
 import json
 import os
+import shutil
+import socket
 import stat
 import subprocess
 import sys
+import tempfile
 import time
 from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -44,6 +50,23 @@ def git(repository: Path, *arguments: str, text: bool = True):
         capture_output=True,
         text=text,
     ).stdout
+
+
+def raw_git(repository: Path, *arguments: str) -> bytes:
+    return git(repository, *arguments, text=False)
+
+
+def bounded_python(program: str, *, stdout_limit: int, timeout: float = 2.0) -> bytes:
+    descriptor = os.open("/", os.O_RDONLY)
+    try:
+        return context_publisher._bounded_process(
+            [sys.executable, "-c", program],
+            pass_fd=descriptor,
+            stdout_limit=stdout_limit,
+            deadline=time.monotonic() + timeout,
+        )
+    finally:
+        os.close(descriptor)
 
 
 def initialize_repository(path: Path) -> Path:
@@ -178,11 +201,98 @@ def test_index_drift_is_manual_review(tmp_path):
     assert observation.previous is None
 
 
-def test_target_symlink_is_manual_review_without_reading_target(tmp_path):
+@pytest.mark.parametrize("operation", ["add", "delete"])
+def test_staged_add_or_delete_is_manual_review(tmp_path, operation):
     repository = initialize_repository(tmp_path / "repo")
+    if operation == "delete":
+        (repository / "CLAUDE.md").write_text("legacy\n")
+    else:
+        (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    if operation == "delete":
+        git(repository, "rm", "-q", "CLAUDE.md")
+    else:
+        (repository / "CLAUDE.md").write_text("staged add\n")
+        git(repository, "add", "CLAUDE.md")
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
+def test_unmerged_index_stages_are_manual_review(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "CLAUDE.md").write_text("legacy\n")
+    commit_all(repository)
+    blob = git(repository, "rev-parse", "HEAD:CLAUDE.md").strip()
+    git(repository, "rm", "--cached", "-q", "CLAUDE.md")
+    index_info = "".join(f"100644 {blob} {stage}\tCLAUDE.md\n" for stage in (1, 2, 3))
+    subprocess.run(
+        [GIT, "update-index", "--index-info"],
+        cwd=repository,
+        env=GIT_ENV,
+        input=index_info,
+        check=True,
+        text=True,
+    )
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
+def test_unexpected_index_mode_is_manual_review(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "CLAUDE.md").write_text("legacy\n")
+    commit_all(repository)
+    blob = git(repository, "rev-parse", "HEAD:CLAUDE.md").strip()
+    index_info = f"120000 {blob}\tCLAUDE.md\n"
+    subprocess.run(
+        [GIT, "update-index", "--index-info"],
+        cwd=repository,
+        env=GIT_ENV,
+        input=index_info,
+        check=True,
+        text=True,
+    )
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
+@pytest.mark.parametrize("parser", [context_publisher._parse_tree, context_publisher._parse_index])
+@pytest.mark.parametrize("shape", ["foreign", "duplicate"])
+def test_plumbing_parser_rejects_foreign_and_duplicate_paths(parser, shape):
+    if parser is context_publisher._parse_tree:
+        prefix = b"100644 blob " + b"a" * 40 + b"\t"
+    else:
+        prefix = b"100644 " + b"a" * 40 + b" 0\t"
+    if shape == "foreign":
+        value = prefix + b"README.md\0"
+    else:
+        value = prefix + b"CLAUDE.md\0" + prefix + b"CLAUDE.md\0"
+
+    with pytest.raises(context_publisher._ObservationFailure):
+        parser(value)
+
+
+def test_target_symlink_is_manual_review_without_reading_target(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
     secret = tmp_path / "secret"
     secret.write_text("must-not-be-read\n")
+    secret_stat = secret.stat()
     os.symlink(secret, repository / "CLAUDE.md")
+    original_read = context_publisher.os.read
+
+    def reject_secret_descriptor(descriptor, count):
+        value = os.fstat(descriptor)
+        assert (value.st_dev, value.st_ino) != (secret_stat.st_dev, secret_stat.st_ino)
+        return original_read(descriptor, count)
+
+    monkeypatch.setattr(context_publisher.os, "read", reject_secret_descriptor)
 
     observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
 
@@ -193,6 +303,8 @@ def test_target_symlink_is_manual_review_without_reading_target(tmp_path):
 
 def test_target_hardlink_is_manual_review(tmp_path):
     repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
     source = tmp_path / "shared"
     source.write_text("shared\n")
     os.link(source, repository / "CLAUDE.md")
@@ -202,12 +314,231 @@ def test_target_hardlink_is_manual_review(tmp_path):
     assert observation.state is GenerationState.MANUAL_REVIEW
 
 
+@pytest.mark.parametrize("kind", ["directory", "fifo", "socket"])
+def test_non_regular_target_types_are_manual_review(tmp_path, kind):
+    cleanup_root = None
+    if kind == "socket":
+        cleanup_root = Path(tempfile.mkdtemp(prefix="d2a-", dir="/tmp"))
+        repository = initialize_repository(cleanup_root / "repo")
+    else:
+        repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    target = repository / "CLAUDE.md"
+    bound_socket = None
+    if kind == "directory":
+        target.mkdir()
+    elif kind == "fifo":
+        os.mkfifo(target)
+    else:
+        bound_socket = socket.socket(socket.AF_UNIX)
+        bound_socket.bind(os.fspath(target))
+    try:
+        observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+    finally:
+        if bound_socket is not None:
+            bound_socket.close()
+        if cleanup_root is not None:
+            shutil.rmtree(cleanup_root)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
+def test_device_target_is_rejected_before_open():
+    parent_fd = os.open("/dev", context_publisher._OPEN_DIRECTORY)
+    try:
+        with pytest.raises(context_publisher._ObservationFailure):
+            context_publisher._read_target(parent_fd, "null", 1024)
+    finally:
+        os.close(parent_fd)
+
+
+def test_steward_parent_symlink_is_manual_review(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    (repository / ".steward").rmdir()
+    foreign = tmp_path / "foreign-steward"
+    foreign.mkdir()
+    os.symlink(foreign, repository / ".steward")
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
+def test_steward_parent_swap_during_observation_is_detected(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    foreign = tmp_path / "foreign-steward"
+    foreign.mkdir()
+    (foreign / "context-snapshot.json").write_text("must-not-be-read\n")
+    displaced = repository / ".steward-original"
+    original_read_worktree = context_publisher._read_worktree
+    swapped = False
+
+    def swap_parent_after_read(root_fd, steward_fd):
+        nonlocal swapped
+        result = original_read_worktree(root_fd, steward_fd)
+        if not swapped:
+            (repository / ".steward").rename(displaced)
+            os.symlink(foreign, repository / ".steward")
+            swapped = True
+        return result
+
+    monkeypatch.setattr(context_publisher, "_read_worktree", swap_parent_after_read)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+    assert observation.race_detected is True
+    assert "must-not-be-read" not in observation.reason
+
+
+def test_oversized_target_is_manual_review(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    limit = context_publisher.PERSISTED_TARGET_MAX_BYTES["CLAUDE.md"]
+    (repository / "CLAUDE.md").write_bytes(b"x" * (limit + 1))
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
+def test_short_read_is_rejected(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    target = repository / "CLAUDE.md"
+    target.write_bytes(b"complete")
+    parent_fd = os.open(repository, context_publisher._OPEN_DIRECTORY)
+    monkeypatch.setattr(context_publisher.os, "read", lambda descriptor, count: b"")
+    try:
+        with pytest.raises(context_publisher._ObservationFailure):
+            context_publisher._read_target(parent_fd, "CLAUDE.md", 1024)
+    finally:
+        os.close(parent_fd)
+
+
+def test_growth_during_read_is_rejected(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    target = repository / "CLAUDE.md"
+    target.write_bytes(b"original")
+    parent_fd = os.open(repository, context_publisher._OPEN_DIRECTORY)
+    original_read = context_publisher.os.read
+    grown = False
+
+    def grow_after_read(descriptor, count):
+        nonlocal grown
+        chunk = original_read(descriptor, count)
+        if not grown and chunk:
+            with target.open("ab") as stream:
+                stream.write(b"growth")
+            grown = True
+        return chunk
+
+    monkeypatch.setattr(context_publisher.os, "read", grow_after_read)
+    try:
+        with pytest.raises(context_publisher._ObservationFailure):
+            context_publisher._read_target(parent_fd, "CLAUDE.md", 1024)
+    finally:
+        os.close(parent_fd)
+
+
+def test_read_error_blocks(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "CLAUDE.md").write_bytes(b"content")
+    parent_fd = os.open(repository, context_publisher._OPEN_DIRECTORY)
+
+    def fail_read(descriptor, count):
+        raise OSError("injected")
+
+    monkeypatch.setattr(context_publisher.os, "read", fail_read)
+    try:
+        with pytest.raises(OSError):
+            context_publisher._read_target(parent_fd, "CLAUDE.md", 1024)
+    finally:
+        os.close(parent_fd)
+
+
+def test_public_observer_fail_closes_read_error_without_leaking_bytes(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+
+    def fail_read(root_fd, steward_fd):
+        raise OSError("secret-target-bytes")
+
+    monkeypatch.setattr(context_publisher, "_read_worktree", fail_read)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+    assert "secret-target-bytes" not in observation.reason
+
+
+def test_target_swap_between_lstat_and_open_is_rejected(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    target = repository / "CLAUDE.md"
+    target.write_bytes(b"original")
+    parent_fd = os.open(repository, context_publisher._OPEN_DIRECTORY)
+    original_open = context_publisher.os.open
+    swapped = False
+
+    def swap_before_open(path, flags, *args, **kwargs):
+        nonlocal swapped
+        if path == "CLAUDE.md" and kwargs.get("dir_fd") == parent_fd and not swapped:
+            target.rename(repository / "displaced")
+            target.write_bytes(b"replacement")
+            swapped = True
+        return original_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(context_publisher.os, "open", swap_before_open)
+    try:
+        with pytest.raises(context_publisher._ObservationFailure):
+            context_publisher._read_target(parent_fd, "CLAUDE.md", 1024)
+    finally:
+        os.close(parent_fd)
+
+
 def test_repository_root_symlink_is_manual_review(tmp_path):
     repository = initialize_repository(tmp_path / "repo")
     link = tmp_path / "repository-link"
     os.symlink(repository, link)
 
     observation = inspect_repository_generation(link, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
+@pytest.mark.parametrize("kind", ["file", "symlink"])
+def test_unsafe_dot_git_shape_is_manual_review(tmp_path, kind):
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    dot_git = repository / ".git"
+    if kind == "file":
+        dot_git.write_text("gitdir: ../foreign\n")
+    else:
+        foreign = tmp_path / "foreign"
+        foreign.mkdir()
+        os.symlink(foreign, dot_git)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
+@pytest.mark.parametrize("relative", ["commondir", "gitdir", "objects/info/alternates"])
+def test_static_git_redirection_is_manual_review(tmp_path, relative):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    redirection = repository / ".git" / relative
+    redirection.parent.mkdir(parents=True, exist_ok=True)
+    redirection.write_text("../foreign\n")
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
 
     assert observation.state is GenerationState.MANUAL_REVIEW
 
@@ -250,6 +581,40 @@ def test_unknown_publisher_signal_is_manual_review(tmp_path):
 
     assert observation.state is GenerationState.MANUAL_REVIEW
     assert observation.previous is None
+
+
+def test_multiple_publisher_signals_are_manual_review(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    (repository / ".context-publish-v1.00000000000000000000000000000000.claude.tmp").touch()
+    (repository / ".context-publish-v1.11111111111111111111111111111111.agents.tmp").touch()
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
+def test_malformed_publisher_signal_is_manual_review(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    (repository / ".context-publish-v1.not-hex.txn").touch()
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
+def test_historical_atomic_file_is_ignored(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    (repository / ".atomic_historical.tmp").touch()
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.ABSENT
 
 
 def test_caller_path_is_not_used_to_select_git(tmp_path, monkeypatch):
@@ -319,6 +684,82 @@ def test_unsafe_fixed_system_git_is_fail_closed(tmp_path, monkeypatch):
     assert observation.state is GenerationState.MANUAL_REVIEW
 
 
+@pytest.mark.parametrize("executable", ["/usr/bin/git", "/usr/bin/python3"])
+@pytest.mark.parametrize("defect", ["symlink", "owner", "writable"])
+def test_system_executable_defects_are_rejected(monkeypatch, executable, defect):
+    original_lstat = context_publisher.os.lstat
+    baseline = original_lstat("/usr/bin/git")
+
+    def defective_lstat(path):
+        if os.fspath(path) != executable:
+            return original_lstat(path)
+        mode = baseline.st_mode
+        owner = 0
+        if defect == "symlink":
+            mode = stat.S_IFLNK | 0o777
+        elif defect == "owner":
+            owner = 1
+        else:
+            mode |= stat.S_IWGRP
+        return SimpleNamespace(st_mode=mode, st_uid=owner)
+
+    monkeypatch.setattr(context_publisher.os, "lstat", defective_lstat)
+
+    with pytest.raises(context_publisher._ObservationFailure):
+        context_publisher._safe_executable((executable,))
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux direct Git contract")
+def test_linux_never_selects_python_helper(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    selected = []
+    original_safe_executable = context_publisher._safe_executable
+
+    def record_selection(candidates):
+        selected.append(candidates)
+        return original_safe_executable(candidates)
+
+    monkeypatch.setattr(context_publisher, "_safe_executable", record_selection)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.ABSENT
+    assert selected
+    assert all(not any("python" in candidate for candidate in candidates) for candidates in selected)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="Darwin fixed helper contract")
+def test_darwin_ignores_path_python_and_blocks_unsafe_fixed_helper(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python3"
+    fake_python.write_text("not executable\n")
+    monkeypatch.setenv("PATH", os.fspath(fake_bin))
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+    assert observation.state is GenerationState.ABSENT
+
+    original_lstat = context_publisher.os.lstat
+
+    def unsafe_python(path):
+        value = original_lstat(path)
+        if os.fspath(path) == "/usr/bin/python3":
+            fields = list(value)
+            fields[0] |= stat.S_IWGRP
+            return os.stat_result(fields)
+        return value
+
+    monkeypatch.setattr(context_publisher.os, "lstat", unsafe_python)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
 @pytest.mark.parametrize(
     "value",
     [
@@ -375,6 +816,9 @@ def test_transient_git_redirection_file_is_detected(tmp_path, monkeypatch, relat
     repository = initialize_repository(tmp_path / "repo")
     (repository / "README.md").write_text("fixture\n")
     commit_all(repository)
+    foreign = initialize_repository(tmp_path / "foreign")
+    (foreign / "README.md").write_text("foreign\n")
+    commit_all(foreign)
     original_git_command = context_publisher._git_command
     injected = False
 
@@ -383,12 +827,40 @@ def test_transient_git_redirection_file_is_detected(tmp_path, monkeypatch, relat
         if not injected:
             redirection = repository / ".git" / relative
             redirection.parent.mkdir(parents=True, exist_ok=True)
-            redirection.write_text("../foreign\n")
-            redirection.unlink()
             injected = True
+            content = ".\n" if relative == "commondir" else f"{foreign / '.git' / 'objects'}\n"
+            redirection.write_text(content)
+            try:
+                return original_git_command(*args, **kwargs)
+            finally:
+                redirection.unlink()
         return original_git_command(*args, **kwargs)
 
     monkeypatch.setattr(context_publisher, "_git_command", insert_and_remove_redirection)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+    assert observation.race_detected is True
+
+
+def test_head_change_between_git_rounds_is_manual_review(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("one\n")
+    commit_all(repository, "one")
+    original_read_git_evidence = context_publisher._read_git_evidence
+    calls = 0
+
+    def commit_after_first_round(*args, **kwargs):
+        nonlocal calls
+        evidence = original_read_git_evidence(*args, **kwargs)
+        calls += 1
+        if calls == 1:
+            (repository / "README.md").write_text("two\n")
+            commit_all(repository, "two")
+        return evidence
+
+    monkeypatch.setattr(context_publisher, "_read_git_evidence", commit_after_first_round)
 
     observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
 
@@ -421,11 +893,45 @@ def test_observation_never_calls_forbidden_write_syscalls(tmp_path, monkeypatch)
     def forbidden(*args, **kwargs):
         pytest.fail("read-only observer invoked a forbidden write syscall")
 
-    monkeypatch.setattr(context_publisher.os, "open", read_only_open)
-    for name in ("chmod", "fsync", "link", "mkdir", "remove", "rename", "replace", "symlink", "unlink", "write"):
-        monkeypatch.setattr(context_publisher.os, name, forbidden)
+    original_git_command = context_publisher._git_command
+    original_import = builtins.__import__
 
-    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+    def read_only_git(git_path, git_fd, arguments, **kwargs):
+        assert arguments[0] in {"cat-file", "ls-files", "ls-tree", "rev-parse"}
+        return original_git_command(git_path, git_fd, arguments, **kwargs)
+
+    def reject_service_registry(name, *args, **kwargs):
+        if "service_registry" in name:
+            pytest.fail("read-only observer imported ServiceRegistry")
+        return original_import(name, *args, **kwargs)
+
+    with monkeypatch.context() as guarded:
+        guarded.setattr(context_publisher.os, "open", read_only_open)
+        for name in (
+            "chmod",
+            "fsync",
+            "link",
+            "mkdir",
+            "remove",
+            "rename",
+            "replace",
+            "symlink",
+            "unlink",
+            "write",
+        ):
+            guarded.setattr(context_publisher.os, name, forbidden)
+        guarded.setattr(Path, "write_bytes", forbidden)
+        guarded.setattr(Path, "write_text", forbidden)
+        guarded.setattr(tempfile, "mkdtemp", forbidden)
+        guarded.setattr(tempfile, "mkstemp", forbidden)
+        guarded.setattr(tempfile, "NamedTemporaryFile", forbidden)
+        guarded.setattr(fcntl, "flock", forbidden)
+        guarded.setattr(socket, "socket", forbidden)
+        guarded.setattr(context_publisher.time, "time", forbidden)
+        guarded.setattr(context_publisher, "_git_command", read_only_git)
+        guarded.setattr(builtins, "__import__", reject_service_registry)
+
+        observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
 
     assert observation.state is GenerationState.ABSENT
 
@@ -434,8 +940,8 @@ def test_observation_never_calls_forbidden_write_syscalls(tmp_path, monkeypatch)
     ("program", "stdout_limit", "timeout"),
     [
         ("import time;time.sleep(5)", 16, 0.1),
-        ("import os;os.write(1,b'x'*4096)", 16, 2.0),
-        ("import os;os.write(2,b'x'*8192)", 16, 2.0),
+        ("import os;os.write(1,b'x'*17)", 16, 2.0),
+        ("import os;os.write(2,b'x'*4097)", 16, 2.0),
     ],
 )
 def test_timeout_and_output_limits_kill_and_reap_child(program, stdout_limit, timeout, monkeypatch):
@@ -466,6 +972,163 @@ def test_timeout_and_output_limits_kill_and_reap_child(program, stdout_limit, ti
         os.kill(child_pid, 0)
 
 
+@pytest.mark.parametrize(
+    ("program", "stdout_limit", "expected"),
+    [
+        ("import os;os.write(1,b'x'*16)", 16, b"x" * 16),
+        ("import os;os.write(2,b'x'*4096)", 16, b""),
+    ],
+)
+def test_stdout_and_stderr_exact_limits_are_accepted(program, stdout_limit, expected):
+    assert bounded_python(program, stdout_limit=stdout_limit) == expected
+
+
+def test_command_timeout_is_exactly_five_seconds():
+    started = time.monotonic()
+    with pytest.raises(context_publisher._ObservationFailure):
+        bounded_python("import time;time.sleep(10)", stdout_limit=16, timeout=20.0)
+    elapsed = time.monotonic() - started
+
+    assert 4.5 <= elapsed <= 7.0
+
+
+def test_repository_deadline_is_exactly_twenty_seconds(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    observed_deadline = None
+    monkeypatch.setattr(context_publisher.time, "monotonic", lambda: 100.0)
+
+    def capture_deadline(git_path, git_fd, deadline):
+        nonlocal observed_deadline
+        observed_deadline = deadline
+        raise context_publisher._ObservationFailure
+
+    monkeypatch.setattr(context_publisher, "_read_git_evidence", capture_deadline)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+    assert observed_deadline == 120.0
+
+
+def test_nonzero_process_exit_is_reaped(monkeypatch):
+    child_pid = None
+    original_popen = context_publisher.subprocess.Popen
+
+    def capture_child(*args, **kwargs):
+        nonlocal child_pid
+        process = original_popen(*args, **kwargs)
+        child_pid = process.pid
+        return process
+
+    monkeypatch.setattr(context_publisher.subprocess, "Popen", capture_child)
+
+    with pytest.raises(context_publisher._ObservationFailure):
+        bounded_python("raise SystemExit(7)", stdout_limit=16)
+
+    assert child_pid is not None
+    with pytest.raises(ProcessLookupError):
+        os.kill(child_pid, 0)
+
+
+def test_nonzero_git_exit_blocks(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    git_fd = os.open(repository / ".git", context_publisher._OPEN_DIRECTORY)
+    try:
+        with pytest.raises(context_publisher._ObservationFailure):
+            context_publisher._git_command(
+                "/usr/bin/git",
+                git_fd,
+                ["not-a-real-plumbing-command"],
+                stdout_limit=4096,
+                deadline=time.monotonic() + 5,
+            )
+    finally:
+        os.close(git_fd)
+
+
+def test_git_plumbing_argv_is_exact_and_blobs_use_cat_file(monkeypatch):
+    head = "a" * 40
+    blob = "b" * 40
+    calls = []
+
+    def fake_git(git_path, git_fd, arguments, **kwargs):
+        calls.append(arguments)
+        if arguments[:3] in (["rev-parse", "--verify", "HEAD"], ["rev-parse", "--verify", "HEAD^{commit}"]):
+            return f"{head}\n".encode()
+        if arguments[0] == "ls-tree":
+            return f"100644 blob {blob}\tCLAUDE.md\0".encode()
+        if arguments[0] == "ls-files":
+            return f"100644 {blob} 0\tCLAUDE.md\0".encode()
+        if arguments[0] == "cat-file":
+            return b"legacy\n"
+        raise AssertionError(arguments)
+
+    monkeypatch.setattr(context_publisher, "_git_command", fake_git)
+
+    observed_head, tree, index, head_blobs = context_publisher._read_git_evidence(
+        "/usr/bin/git", 7, time.monotonic() + 20
+    )
+
+    assert observed_head == head
+    assert tree["CLAUDE.md"].blob == blob
+    assert index["CLAUDE.md"].blob == blob
+    assert head_blobs["CLAUDE.md"] == b"legacy\n"
+    assert calls[2] == ["ls-tree", "-z", "--full-tree", head, "--", *context_publisher._TARGETS]
+    assert calls[-1] == ["cat-file", "blob", blob]
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux inherited FD contract")
+def test_linux_git_uses_proc_fd_directly_without_helper(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    git_fd = os.open(repository / ".git", context_publisher._OPEN_DIRECTORY)
+    captured = {}
+    observed_proc_paths = []
+    observed_proc_stats = []
+    original_stat = context_publisher.os.stat
+
+    def capture_stat(path, *args, **kwargs):
+        if os.fspath(path).startswith("/proc/self/fd/"):
+            observed_proc_paths.append(os.fspath(path))
+            observed_proc_stats.append(original_stat(path, *args, **kwargs))
+            return observed_proc_stats[-1]
+        return original_stat(path, *args, **kwargs)
+
+    def capture_command(arguments, **kwargs):
+        captured["arguments"] = arguments
+        captured.update(kwargs)
+        return b""
+
+    monkeypatch.setattr(context_publisher.os, "stat", capture_stat)
+    monkeypatch.setattr(context_publisher, "_bounded_process", capture_command)
+    try:
+        expected = os.fstat(git_fd)
+        context_publisher._git_command(
+            "/usr/bin/git",
+            git_fd,
+            ["rev-parse", "--verify", "HEAD"],
+            stdout_limit=4096,
+            deadline=time.monotonic() + 5,
+        )
+    finally:
+        os.close(git_fd)
+
+    proc_path = f"/proc/self/fd/{git_fd}"
+    assert observed_proc_paths == [proc_path]
+    proc_stat = observed_proc_stats[0]
+    assert (proc_stat.st_dev, proc_stat.st_ino) == (expected.st_dev, expected.st_ino)
+    assert captured["arguments"] == [
+        "/usr/bin/git",
+        f"--git-dir={proc_path}",
+        "rev-parse",
+        "--verify",
+        "HEAD",
+    ]
+    assert all("python" not in argument for argument in captured["arguments"])
+    assert captured["pass_fd"] == git_fd
+
+
 @pytest.mark.skipif(sys.platform != "darwin", reason="Darwin helper contract")
 def test_darwin_helper_binds_expected_fd_and_has_no_repository_path(tmp_path, monkeypatch):
     repository = initialize_repository(tmp_path / "repo")
@@ -478,11 +1141,12 @@ def test_darwin_helper_binds_expected_fd_and_has_no_repository_path(tmp_path, mo
         return b""
 
     monkeypatch.setattr(context_publisher, "_bounded_process", capture_command)
+    adversarial = "HEAD;ignore-contract\n--git-dir=/foreign"
     try:
         context_publisher._git_command(
             "/usr/bin/git",
             git_fd,
-            ["rev-parse", "--verify", "HEAD"],
+            ["rev-parse", "--verify", adversarial],
             stdout_limit=4096,
             deadline=time.monotonic() + 5,
         )
@@ -493,6 +1157,7 @@ def test_darwin_helper_binds_expected_fd_and_has_no_repository_path(tmp_path, mo
     arguments = captured["arguments"]
     assert arguments[:5] == ["/usr/bin/python3", "-I", "-S", "-c", context_publisher._DARWIN_HELPER]
     assert arguments[5:8] == [str(git_fd), str(git_stat.st_dev), str(git_stat.st_ino)]
+    assert arguments[8:] == ["/usr/bin/git", "rev-parse", "--verify", adversarial]
     assert os.fspath(repository) not in "\0".join(arguments)
     assert captured["pass_fd"] == git_fd
 
@@ -523,35 +1188,97 @@ def test_in_place_mutation_on_same_inode_is_detected(tmp_path, monkeypatch):
     assert observation.race_detected is True
 
 
+def test_mutation_after_final_git_reference_is_detected_by_second_read(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    target = repository / "CLAUDE.md"
+    target.write_text("original\n")
+    commit_all(repository)
+    original_read = context_publisher._read_worktree
+    calls = 0
+
+    def mutate_before_second_read(root_fd, steward_fd):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            target.write_text("mutated!\n")
+        return original_read(root_fd, steward_fd)
+
+    monkeypatch.setattr(context_publisher, "_read_worktree", mutate_before_second_read)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+    assert observation.race_detected is True
+
+
 def test_git_and_worktree_remain_bound_after_root_replacement(tmp_path, monkeypatch):
     repository = initialize_repository(tmp_path / "repo")
     (repository / "CLAUDE.md").write_text("original\n")
     commit_all(repository, "original")
     original_head = git(repository, "rev-parse", "HEAD").strip()
+    original_blob = git(repository, "rev-parse", "HEAD:CLAUDE.md").strip()
 
     replacement = initialize_repository(tmp_path / "replacement")
     (replacement / "CLAUDE.md").write_text("replacement\n")
     commit_all(replacement, "replacement")
-    assert git(replacement, "rev-parse", "HEAD").strip() != original_head
+    replacement_head = git(replacement, "rev-parse", "HEAD").strip()
+    replacement_blob = git(replacement, "rev-parse", "HEAD:CLAUDE.md").strip()
+    assert replacement_head != original_head
+    assert replacement_blob != original_blob
+
+    pathspec = ("--", *context_publisher._TARGETS)
+    original_tree = raw_git(repository, "ls-tree", "-z", "--full-tree", original_head, *pathspec)
+    replacement_tree = raw_git(replacement, "ls-tree", "-z", "--full-tree", replacement_head, *pathspec)
+    original_index = raw_git(repository, "ls-files", "--stage", "-z", *pathspec)
+    replacement_index = raw_git(replacement, "ls-files", "--stage", "-z", *pathspec)
+    assert original_tree != replacement_tree
+    assert original_index != replacement_index
 
     displaced = tmp_path / "displaced"
     original_git_command = context_publisher._git_command
-    replaced = False
+    original_popen = context_publisher.subprocess.Popen
+    captured_tree = []
+    captured_index = []
+    captured_outputs = []
 
-    def replace_before_first_git(*args, **kwargs):
-        nonlocal replaced
-        if not replaced:
-            repository.rename(displaced)
-            replacement.rename(repository)
-            replaced = True
-        return original_git_command(*args, **kwargs)
+    def fail_parent_cwd_mutation(*args, **kwargs):
+        pytest.fail("Steward parent process changed cwd")
 
-    monkeypatch.setattr(context_publisher, "_git_command", replace_before_first_git)
+    def reject_preexec(*args, **kwargs):
+        assert "preexec_fn" not in kwargs
+        return original_popen(*args, **kwargs)
+
+    def replace_during_every_git(*args, **kwargs):
+        repository.rename(displaced)
+        replacement.rename(repository)
+        try:
+            output = original_git_command(*args, **kwargs)
+        finally:
+            repository.rename(replacement)
+            displaced.rename(repository)
+        arguments = args[2]
+        captured_outputs.append(output)
+        if arguments[0] == "ls-tree":
+            captured_tree.append(output)
+        elif arguments[0] == "ls-files":
+            captured_index.append(output)
+        return output
+
+    monkeypatch.setattr(context_publisher.os, "chdir", fail_parent_cwd_mutation)
+    monkeypatch.setattr(context_publisher.os, "fchdir", fail_parent_cwd_mutation)
+    monkeypatch.setattr(context_publisher.subprocess, "Popen", reject_preexec)
+    monkeypatch.setattr(context_publisher, "_git_command", replace_during_every_git)
 
     observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
 
     assert observation.state is GenerationState.LEGACY_BOOTSTRAP
     assert observation.head == original_head
+    assert captured_tree == [original_tree, original_tree]
+    assert captured_index == [original_index, original_index]
+    assert all(value != replacement_tree for value in captured_tree)
+    assert all(value != replacement_index for value in captured_index)
+    assert all(replacement_head.encode("ascii") not in output for output in captured_outputs)
+    assert repository.exists() and replacement.exists() and not displaced.exists()
 
 
 def test_generated_partial_state_is_mixed(tmp_path):
@@ -563,4 +1290,33 @@ def test_generated_partial_state_is_mixed(tmp_path):
     observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
 
     assert observation.state is GenerationState.MIXED
+    assert observation.previous is None
+
+
+@pytest.mark.parametrize(
+    "selected",
+    [
+        ("CLAUDE.md",),
+        (".steward/context-snapshot.json",),
+        (".steward/context-publication.json",),
+        (".steward/context-snapshot.json", ".steward/context-publication.json"),
+        ("CLAUDE.md", "AGENTS.md", ".steward/context-snapshot.json"),
+    ],
+)
+def test_each_partial_generated_combination_is_never_absent_or_legacy(tmp_path, candidates, selected):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    values = {
+        "CLAUDE.md": candidates.claude_md,
+        "AGENTS.md": candidates.agents_md,
+        ".steward/context-snapshot.json": candidates.snapshot_artifact,
+        ".steward/context-publication.json": candidates.publication_artifact,
+    }
+    for relative in selected:
+        (repository / relative).write_bytes(values[relative])
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state in {GenerationState.MIXED, GenerationState.MANUAL_REVIEW}
     assert observation.previous is None

--- a/tests/test_context_publisher.py
+++ b/tests/test_context_publisher.py
@@ -1,0 +1,171 @@
+"""Read-only repository observation contracts for Context Bridge D2a."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from steward.context_contract import ConstitutionAttestation
+from steward.context_publisher import GenerationState, inspect_repository_generation
+from steward.context_rendering import PublicationCandidates, build_publication_candidates
+
+APPROVED_ATTESTATION = ConstitutionAttestation(
+    c0_sha256="f23ab40415edf4947f12fd8ff98cf13aa8f4fbfffe029ae10aa6111fc04976a3",
+    source_blob="f428d5856a5c525e002c301890777748effbeb4e",
+    reviewed_at_commit="59169f2ca7822deeea068d206863d61b45e8401e",
+)
+GIT = "/usr/bin/git"
+GIT_ENV = {
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_NOSYSTEM": "1",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "LANG": "C",
+    "LC_ALL": "C",
+    "PATH": "/usr/bin:/bin",
+}
+
+
+def git(repository: Path, *arguments: str, text: bool = True):
+    return subprocess.run(
+        [GIT, *arguments],
+        cwd=repository,
+        env=GIT_ENV,
+        check=True,
+        capture_output=True,
+        text=text,
+    ).stdout
+
+
+def initialize_repository(path: Path) -> Path:
+    path.mkdir()
+    git(path, "init", "-q")
+    git(path, "config", "user.name", "Context Test")
+    git(path, "config", "user.email", "context@example.invalid")
+    (path / ".steward").mkdir()
+    return path
+
+
+def commit_all(repository: Path, message: str = "fixture") -> None:
+    git(repository, "add", "-A")
+    git(repository, "commit", "-qm", message)
+
+
+def write_candidates(repository: Path, candidates: PublicationCandidates) -> None:
+    (repository / "CLAUDE.md").write_bytes(candidates.claude_md)
+    (repository / "AGENTS.md").write_bytes(candidates.agents_md)
+    (repository / ".steward" / "context-snapshot.json").write_bytes(candidates.snapshot_artifact)
+    (repository / ".steward" / "context-publication.json").write_bytes(candidates.publication_artifact)
+
+
+@pytest.fixture
+def models():
+    vector = json.loads(Path("specs/context_bridge_evidence/FEATURE_04_HASH_VECTORS.json").read_text())
+    return vector["payload"]["model"], vector["snapshot"]["model"]
+
+
+@pytest.fixture
+def candidates(models):
+    payload, snapshot = models
+    return build_publication_candidates(payload, snapshot)
+
+
+@pytest.fixture
+def candidate_attestation(candidates):
+    constitution = json.loads(candidates.snapshot_artifact)["snapshot"]["constitution"]
+    return ConstitutionAttestation(
+        c0_sha256=constitution["sha256"],
+        source_blob=constitution["source_blob"],
+        reviewed_at_commit=constitution["reviewed_at_commit"],
+    )
+
+
+def test_real_checkout_is_legacy_bootstrap_without_previous_record():
+    observation = inspect_repository_generation(Path.cwd(), APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.LEGACY_BOOTSTRAP
+    assert observation.previous is None
+    assert observation.head == git(Path.cwd(), "rev-parse", "HEAD").strip()
+
+
+def test_clean_four_target_absence_is_distinct(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.ABSENT
+    assert observation.previous is None
+
+
+def test_head_bound_generation_is_valid_and_returns_previous(tmp_path, candidates, candidate_attestation):
+    repository = initialize_repository(tmp_path / "repo")
+    write_candidates(repository, candidates)
+    commit_all(repository)
+
+    observation = inspect_repository_generation(repository, candidate_attestation)
+
+    assert observation.state is GenerationState.VALID
+    assert observation.previous is not None
+    assert observation.previous.payload_hash == json.loads(candidates.publication_artifact)["previous"]["payload_hash"]
+
+
+def test_coherent_uncommitted_generation_is_unbound_without_previous(
+    tmp_path,
+    models,
+    candidates,
+    candidate_attestation,
+):
+    repository = initialize_repository(tmp_path / "repo")
+    write_candidates(repository, candidates)
+    commit_all(repository)
+    payload, snapshot = models
+    payload["observations"]["provider"] = "unknown"
+    snapshot["observations"]["provider"] = "unknown"
+    changed = build_publication_candidates(payload, snapshot)
+    write_candidates(repository, changed)
+
+    observation = inspect_repository_generation(repository, candidate_attestation)
+
+    assert observation.state is GenerationState.UNBOUND
+    assert observation.previous is None
+
+
+def test_index_drift_is_manual_review(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "CLAUDE.md").write_text("legacy\n")
+    commit_all(repository)
+    (repository / "CLAUDE.md").write_text("staged\n")
+    git(repository, "add", "CLAUDE.md")
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+    assert observation.previous is None
+
+
+def test_target_symlink_is_manual_review_without_reading_target(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    secret = tmp_path / "secret"
+    secret.write_text("must-not-be-read\n")
+    os.symlink(secret, repository / "CLAUDE.md")
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+    assert observation.previous is None
+    assert "must-not-be-read" not in observation.reason
+
+
+def test_generated_partial_state_is_mixed(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "CLAUDE.md").write_text("<!-- steward-context:dynamic:v1:begin -->\n")
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MIXED
+    assert observation.previous is None

--- a/tests/test_context_publisher.py
+++ b/tests/test_context_publisher.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import subprocess
+import sys
+import time
 from copy import deepcopy
 from pathlib import Path
 
@@ -221,6 +224,22 @@ def test_exact_transaction_signal_is_mixed(tmp_path):
     assert observation.publisher_signal is True
 
 
+def test_complete_valid_generation_with_transaction_signal_is_mixed(
+    tmp_path,
+    candidates,
+    candidate_attestation,
+):
+    repository = initialize_repository(tmp_path / "repo")
+    write_candidates(repository, candidates)
+    commit_all(repository)
+    (repository / ".steward" / ".context-publish-v1.00000000000000000000000000000000.txn").touch()
+
+    observation = inspect_repository_generation(repository, candidate_attestation)
+
+    assert observation.state is GenerationState.MIXED
+    assert observation.previous is None
+
+
 def test_unknown_publisher_signal_is_manual_review(tmp_path):
     repository = initialize_repository(tmp_path / "repo")
     (repository / "README.md").write_text("fixture\n")
@@ -247,6 +266,136 @@ def test_caller_path_is_not_used_to_select_git(tmp_path, monkeypatch):
     assert observation.state is GenerationState.ABSENT
 
 
+def test_child_environment_is_an_exact_allowlist(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    captured_environments = []
+    original_popen = context_publisher.subprocess.Popen
+
+    def capture_environment(*args, **kwargs):
+        captured_environments.append(kwargs["env"])
+        return original_popen(*args, **kwargs)
+
+    monkeypatch.setattr(context_publisher.subprocess, "Popen", capture_environment)
+    monkeypatch.setenv("HOME", "/untrusted")
+    monkeypatch.setenv("GIT_OBJECT_DIRECTORY", "/untrusted")
+    monkeypatch.setenv("DYLD_INSERT_LIBRARIES", "/untrusted")
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.ABSENT
+    assert captured_environments
+    assert all(environment == context_publisher._CHILD_ENV for environment in captured_environments)
+
+
+def test_unsafe_executable_path_is_rejected(tmp_path):
+    executable = tmp_path / "git"
+    executable.write_text("not trusted\n")
+    executable.chmod(0o777)
+
+    with pytest.raises(context_publisher._ObservationFailure):
+        context_publisher._safe_executable((os.fspath(executable),))
+
+
+def test_unsafe_fixed_system_git_is_fail_closed(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    original_lstat = context_publisher.os.lstat
+
+    def unsafe_git(path):
+        value = original_lstat(path)
+        if os.fspath(path) in {"/usr/bin/git", "/bin/git"} and stat.S_ISREG(value.st_mode):
+            fields = list(value)
+            fields[0] |= stat.S_IWGRP
+            return os.stat_result(fields)
+        return value
+
+    monkeypatch.setattr(context_publisher.os, "lstat", unsafe_git)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        b"100644 blob " + b"a" * 40 + b"\tCLAUDE.md",
+        b"100644 blob " + b"a" * 40 + b"\tCLAUDE.md\0\0",
+    ],
+)
+def test_tree_parser_rejects_malformed_nul_termination(value):
+    with pytest.raises(context_publisher._ObservationFailure):
+        context_publisher._parse_tree(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        b"100644 " + b"a" * 40 + b" 0\tCLAUDE.md",
+        b"100644 " + b"a" * 40 + b" 0\tCLAUDE.md\0\0",
+    ],
+)
+def test_index_parser_rejects_malformed_nul_termination(value):
+    with pytest.raises(context_publisher._ObservationFailure):
+        context_publisher._parse_index(value)
+
+
+def test_worktree_mode_is_observed_not_invented(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    target = repository / "CLAUDE.md"
+    target.write_text("untracked\n")
+    target.chmod(0o755)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.targets["CLAUDE.md"].worktree_mode == "100755"
+
+
+def test_head_pointing_at_annotated_tag_is_manual_review(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "CLAUDE.md").write_text("legacy\n")
+    commit_all(repository)
+    git(repository, "tag", "-a", "fixture-tag", "-m", "fixture")
+    tag_object = git(repository, "rev-parse", "fixture-tag^{tag}").strip()
+    (repository / ".git" / "HEAD").write_text(f"{tag_object}\n")
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+    assert observation.previous is None
+
+
+@pytest.mark.parametrize("relative", ["commondir", "objects/info/alternates"])
+def test_transient_git_redirection_file_is_detected(tmp_path, monkeypatch, relative):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    original_git_command = context_publisher._git_command
+    injected = False
+
+    def insert_and_remove_redirection(*args, **kwargs):
+        nonlocal injected
+        if not injected:
+            redirection = repository / ".git" / relative
+            redirection.parent.mkdir(parents=True, exist_ok=True)
+            redirection.write_text("../foreign\n")
+            redirection.unlink()
+            injected = True
+        return original_git_command(*args, **kwargs)
+
+    monkeypatch.setattr(context_publisher, "_git_command", insert_and_remove_redirection)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+    assert observation.race_detected is True
+
+
 def test_observation_does_not_change_git_state(tmp_path):
     repository = initialize_repository(tmp_path / "repo")
     (repository / "README.md").write_text("fixture\n")
@@ -256,6 +405,96 @@ def test_observation_does_not_change_git_state(tmp_path):
     inspect_repository_generation(repository, APPROVED_ATTESTATION)
 
     assert git(repository, "status", "--porcelain=v1", "-z", text=False) == before
+
+
+def test_observation_never_calls_forbidden_write_syscalls(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    original_open = context_publisher.os.open
+    forbidden_flags = os.O_WRONLY | os.O_RDWR | os.O_CREAT | os.O_TRUNC | os.O_APPEND
+
+    def read_only_open(path, flags, *args, **kwargs):
+        assert flags & forbidden_flags == 0
+        return original_open(path, flags, *args, **kwargs)
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("read-only observer invoked a forbidden write syscall")
+
+    monkeypatch.setattr(context_publisher.os, "open", read_only_open)
+    for name in ("chmod", "fsync", "link", "mkdir", "remove", "rename", "replace", "symlink", "unlink", "write"):
+        monkeypatch.setattr(context_publisher.os, name, forbidden)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.ABSENT
+
+
+@pytest.mark.parametrize(
+    ("program", "stdout_limit", "timeout"),
+    [
+        ("import time;time.sleep(5)", 16, 0.1),
+        ("import os;os.write(1,b'x'*4096)", 16, 2.0),
+        ("import os;os.write(2,b'x'*8192)", 16, 2.0),
+    ],
+)
+def test_timeout_and_output_limits_kill_and_reap_child(program, stdout_limit, timeout, monkeypatch):
+    child_pid = None
+    original_popen = context_publisher.subprocess.Popen
+
+    def capture_child(*args, **kwargs):
+        nonlocal child_pid
+        process = original_popen(*args, **kwargs)
+        child_pid = process.pid
+        return process
+
+    monkeypatch.setattr(context_publisher.subprocess, "Popen", capture_child)
+    descriptor = os.open("/", os.O_RDONLY)
+    try:
+        with pytest.raises(context_publisher._ObservationFailure):
+            context_publisher._bounded_process(
+                [sys.executable, "-c", program],
+                pass_fd=descriptor,
+                stdout_limit=stdout_limit,
+                deadline=time.monotonic() + timeout,
+            )
+    finally:
+        os.close(descriptor)
+
+    assert child_pid is not None
+    with pytest.raises(ProcessLookupError):
+        os.kill(child_pid, 0)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="Darwin helper contract")
+def test_darwin_helper_binds_expected_fd_and_has_no_repository_path(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    git_fd = os.open(repository / ".git", context_publisher._OPEN_DIRECTORY)
+    captured = {}
+
+    def capture_command(arguments, **kwargs):
+        captured["arguments"] = arguments
+        captured.update(kwargs)
+        return b""
+
+    monkeypatch.setattr(context_publisher, "_bounded_process", capture_command)
+    try:
+        context_publisher._git_command(
+            "/usr/bin/git",
+            git_fd,
+            ["rev-parse", "--verify", "HEAD"],
+            stdout_limit=4096,
+            deadline=time.monotonic() + 5,
+        )
+        git_stat = os.fstat(git_fd)
+    finally:
+        os.close(git_fd)
+
+    arguments = captured["arguments"]
+    assert arguments[:5] == ["/usr/bin/python3", "-I", "-S", "-c", context_publisher._DARWIN_HELPER]
+    assert arguments[5:8] == [str(git_fd), str(git_stat.st_dev), str(git_stat.st_ino)]
+    assert os.fspath(repository) not in "\0".join(arguments)
+    assert captured["pass_fd"] == git_fd
 
 
 def test_in_place_mutation_on_same_inode_is_detected(tmp_path, monkeypatch):

--- a/tests/test_context_publisher.py
+++ b/tests/test_context_publisher.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
 
+import steward.context_publisher as context_publisher
 from steward.context_contract import ConstitutionAttestation
 from steward.context_publisher import GenerationState, inspect_repository_generation
 from steward.context_rendering import PublicationCandidates, build_publication_candidates
@@ -19,6 +21,7 @@ APPROVED_ATTESTATION = ConstitutionAttestation(
     reviewed_at_commit="59169f2ca7822deeea068d206863d61b45e8401e",
 )
 GIT = "/usr/bin/git"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 GIT_ENV = {
     "GIT_CONFIG_GLOBAL": "/dev/null",
     "GIT_CONFIG_NOSYSTEM": "1",
@@ -84,11 +87,11 @@ def candidate_attestation(candidates):
 
 
 def test_real_checkout_is_legacy_bootstrap_without_previous_record():
-    observation = inspect_repository_generation(Path.cwd(), APPROVED_ATTESTATION)
+    observation = inspect_repository_generation(REPOSITORY_ROOT, APPROVED_ATTESTATION)
 
     assert observation.state is GenerationState.LEGACY_BOOTSTRAP
     assert observation.previous is None
-    assert observation.head == git(Path.cwd(), "rev-parse", "HEAD").strip()
+    assert observation.head == git(REPOSITORY_ROOT, "rev-parse", "HEAD").strip()
 
 
 def test_clean_four_target_absence_is_distinct(tmp_path):
@@ -114,6 +117,30 @@ def test_head_bound_generation_is_valid_and_returns_previous(tmp_path, candidate
     assert observation.previous.payload_hash == json.loads(candidates.publication_artifact)["previous"]["payload_hash"]
 
 
+def test_head_bound_generation_with_mismatched_attestation_is_unattested(tmp_path, candidates):
+    repository = initialize_repository(tmp_path / "repo")
+    write_candidates(repository, candidates)
+    commit_all(repository)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.UNATTESTED
+    assert observation.previous is None
+
+
+def test_head_bound_malformed_generation_is_invalid(tmp_path, candidates, candidate_attestation):
+    repository = initialize_repository(tmp_path / "repo")
+    write_candidates(repository, candidates)
+    publication = repository / ".steward" / "context-publication.json"
+    publication.write_bytes(publication.read_bytes()[:-1] + b"]")
+    commit_all(repository)
+
+    observation = inspect_repository_generation(repository, candidate_attestation)
+
+    assert observation.state is GenerationState.INVALID
+    assert observation.previous is None
+
+
 def test_coherent_uncommitted_generation_is_unbound_without_previous(
     tmp_path,
     models,
@@ -123,9 +150,9 @@ def test_coherent_uncommitted_generation_is_unbound_without_previous(
     repository = initialize_repository(tmp_path / "repo")
     write_candidates(repository, candidates)
     commit_all(repository)
-    payload, snapshot = models
-    payload["observations"]["provider"] = "unknown"
-    snapshot["observations"]["provider"] = "unknown"
+    payload, snapshot = deepcopy(models)
+    payload["observations"]["health"]["provider"] = "degraded"
+    snapshot["observations"]["health"]["provider"] = "degraded"
     changed = build_publication_candidates(payload, snapshot)
     write_candidates(repository, changed)
 
@@ -161,8 +188,137 @@ def test_target_symlink_is_manual_review_without_reading_target(tmp_path):
     assert "must-not-be-read" not in observation.reason
 
 
+def test_target_hardlink_is_manual_review(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    source = tmp_path / "shared"
+    source.write_text("shared\n")
+    os.link(source, repository / "CLAUDE.md")
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
+def test_repository_root_symlink_is_manual_review(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    link = tmp_path / "repository-link"
+    os.symlink(repository, link)
+
+    observation = inspect_repository_generation(link, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+
+
+def test_exact_transaction_signal_is_mixed(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    (repository / ".context-publish-v1.00000000000000000000000000000000.claude.tmp").touch()
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MIXED
+    assert observation.publisher_signal is True
+
+
+def test_unknown_publisher_signal_is_manual_review(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    (repository / ".context-publish-surprise").touch()
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+    assert observation.previous is None
+
+
+def test_caller_path_is_not_used_to_select_git(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "git").write_text("unexpected\n")
+    monkeypatch.setenv("PATH", os.fspath(fake_bin))
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.ABSENT
+
+
+def test_observation_does_not_change_git_state(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+    before = git(repository, "status", "--porcelain=v1", "-z", text=False)
+
+    inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert git(repository, "status", "--porcelain=v1", "-z", text=False) == before
+
+
+def test_in_place_mutation_on_same_inode_is_detected(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    target = repository / "CLAUDE.md"
+    target.write_text("original\n")
+    commit_all(repository)
+    inode = target.stat().st_ino
+    original_read = context_publisher._read_worktree
+    calls = 0
+
+    def mutate_after_first_read(root_fd, steward_fd):
+        nonlocal calls
+        result = original_read(root_fd, steward_fd)
+        calls += 1
+        if calls == 1:
+            target.write_text("mutated!\n")
+            assert target.stat().st_ino == inode
+        return result
+
+    monkeypatch.setattr(context_publisher, "_read_worktree", mutate_after_first_read)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.MANUAL_REVIEW
+    assert observation.race_detected is True
+
+
+def test_git_and_worktree_remain_bound_after_root_replacement(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "CLAUDE.md").write_text("original\n")
+    commit_all(repository, "original")
+    original_head = git(repository, "rev-parse", "HEAD").strip()
+
+    replacement = initialize_repository(tmp_path / "replacement")
+    (replacement / "CLAUDE.md").write_text("replacement\n")
+    commit_all(replacement, "replacement")
+    assert git(replacement, "rev-parse", "HEAD").strip() != original_head
+
+    displaced = tmp_path / "displaced"
+    original_git_command = context_publisher._git_command
+    replaced = False
+
+    def replace_before_first_git(*args, **kwargs):
+        nonlocal replaced
+        if not replaced:
+            repository.rename(displaced)
+            replacement.rename(repository)
+            replaced = True
+        return original_git_command(*args, **kwargs)
+
+    monkeypatch.setattr(context_publisher, "_git_command", replace_before_first_git)
+
+    observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)
+
+    assert observation.state is GenerationState.LEGACY_BOOTSTRAP
+    assert observation.head == original_head
+
+
 def test_generated_partial_state_is_mixed(tmp_path):
     repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
     (repository / "CLAUDE.md").write_text("<!-- steward-context:dynamic:v1:begin -->\n")
 
     observation = inspect_repository_generation(repository, APPROVED_ATTESTATION)

--- a/tests/test_context_rendering.py
+++ b/tests/test_context_rendering.py
@@ -251,6 +251,22 @@ def test_constitution_bound_generation_rejects_wrong_attestation_type(detached_c
     assert exc_info.value.code == "invalid_type"
 
 
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"schema": "steward.context.constitution-attestation/v2"},
+        {"status": "unverified"},
+    ],
+)
+def test_constitution_bound_generation_rejects_attestation_schema_or_status(detached_candidates, mutation):
+    attestation = replace(attestation_for_candidates(detached_candidates), **mutation)
+
+    with pytest.raises(ContractViolation) as exc_info:
+        validate_constitution_bound_persisted_generation(detached_candidates, attestation)
+
+    assert exc_info.value.code == "invalid_schema"
+
+
 def test_publication_artifact_bytes_alone_are_not_a_trusted_record(detached_candidates):
     with pytest.raises(ContractViolation) as exc_info:
         validate_persisted_generation(detached_candidates.publication_artifact)  # type: ignore[arg-type]

--- a/tests/test_context_rendering.py
+++ b/tests/test_context_rendering.py
@@ -12,10 +12,17 @@ from pathlib import Path
 
 import pytest
 
-from steward.context_contract import ContractViolation, OutputMode, canonical_json_bytes, consumer_output_hash
+from steward.context_contract import (
+    ConstitutionAttestation,
+    ContractViolation,
+    OutputMode,
+    canonical_json_bytes,
+    consumer_output_hash,
+)
 from steward.context_rendering import (
     PublicationCandidates,
     build_publication_candidates,
+    validate_constitution_bound_persisted_generation,
     validate_persisted_generation,
     validate_publication_candidates,
 )
@@ -205,6 +212,43 @@ def test_persisted_generation_accepts_nullable_comparison_state(models):
     previous = validate_persisted_generation(detached)
 
     assert dict(previous.comparison_state) == snapshot["comparison_state"]
+
+
+def attestation_for_candidates(candidates: PublicationCandidates) -> ConstitutionAttestation:
+    snapshot = json.loads(candidates.snapshot_artifact)["snapshot"]["constitution"]
+    return ConstitutionAttestation(
+        c0_sha256=snapshot["sha256"],
+        source_blob=snapshot["source_blob"],
+        reviewed_at_commit=snapshot["reviewed_at_commit"],
+    )
+
+
+def test_constitution_bound_generation_accepts_exact_external_attestation(detached_candidates):
+    previous = validate_constitution_bound_persisted_generation(
+        detached_candidates,
+        attestation_for_candidates(detached_candidates),
+    )
+
+    assert previous == validate_persisted_generation(detached_candidates)
+
+
+@pytest.mark.parametrize("field", ["c0_sha256", "source_blob", "reviewed_at_commit"])
+def test_constitution_bound_generation_rejects_each_external_mismatch(detached_candidates, field):
+    attestation = attestation_for_candidates(detached_candidates)
+    bad_length = 64 if field == "c0_sha256" else 40
+    mismatched = replace(attestation, **{field: "0" * bad_length})
+
+    with pytest.raises(ContractViolation) as exc_info:
+        validate_constitution_bound_persisted_generation(detached_candidates, mismatched)
+
+    assert exc_info.value.code == "inconsistent"
+
+
+def test_constitution_bound_generation_rejects_wrong_attestation_type(detached_candidates):
+    with pytest.raises(ContractViolation) as exc_info:
+        validate_constitution_bound_persisted_generation(detached_candidates, object())  # type: ignore[arg-type]
+
+    assert exc_info.value.code == "invalid_type"
 
 
 def test_publication_artifact_bytes_alone_are_not_a_trusted_record(detached_candidates):


### PR DESCRIPTION
## Scope

Implements only the approved D2a read-only repository observation contract from merged PR #675.

- exposes strict Constitution-attestation validation without creating a second language
- binds the existing D1 generation proof to the external attestation
- adds a read-only, FD-pinned Git/worktree observer for the four fixed V1 targets
- classifies `legacy_bootstrap`, `absent`, `valid`, `unattested`, `unbound`, `mixed`, `invalid`, and `manual_review`
- returns a `PreviousPublishedRecord` only for a byte-exact, HEAD-bound, Constitution-attested generation

## Security boundaries

- no writes, locks, journals, recovery, bootstrap, cleanup, publisher decision, caller, workflow, or activation
- Git and worktree are acquired below the same pinned repository-root FD
- Git executable and child environment are allowlisted
- Linux uses the reviewed `/proc/self/fd/<git-dir-fd>` primitive
- Darwin uses the reviewed isolated `/usr/bin/python3` `fchdir()` helper
- target reads reject symlinks and hardlinks and use pre/post `fstat()` plus a complete second read
- HEAD, index, HEAD blobs, worktree bytes, and publisher signals are double-read

## Commits

- `cee3282d` red contract tests
- `b316013b` D2a implementation and adversarial tests

## Local verification

- `ruff check steward/ tests/` — passed
- `ruff format --check steward/ tests/` — passed
- targeted Bandit scan for all changed product modules — passed
- `tests/test_context_publisher.py` — 17 passed
- directly affected attestation/publish/previous contract tests — 9 passed
- rendering + initial D2a contract suite passed before the final adversarial additions; full matrix is intentionally left to CI

## Drift

The branch is based on `db884a1d50eddd9eb4a42a1835581e3406a6f527`. Current `main` drift is limited to runtime/federation-state paths and does not overlap this PR.

## Gate

D2b remains fully blocked. Do not infer authorization for writes, locking, journaling, recovery, bootstrap, delivery, workflows, callers, or activation from this PR.


## Adversarial review fixes (`c2fadf3f`)

- any exact transaction signal now forces `mixed`, including a complete valid generation
- Git layout fingerprint covers `.git`, `objects`, and `objects/info` before and after both Git rounds and immediately before classification
- raw `HEAD` must equal `HEAD^{commit}`; annotated-tag HEADs fail closed
- tree/index parsers require exactly terminated NUL records
- worktree mode is reported from `fstat()`, not synthesized
- parent stdin uses a read-only `/dev/null` FD; forbidden write-syscall purity is directly tested
- adds direct tests for transient commondir/alternates insertion, exact child env, unsafe executables, timeout/stdout/stderr limits with reaping, Darwin helper argv binding, and all review findings

Updated local gates: 87 D1/D2a tests passed; 9 directly affected contract tests passed; full Ruff format/lint and changed-scope Bandit passed.


## Complete G2 minimum matrix (`de411167`)

- `ls-tree -z --full-tree` now matches the approved plumbing argv exactly
- exact stdout/stderr limit and +1-byte tests; exact 5-second command and 20-second inspection deadline tests
- nonzero Git exit, process termination, and reaping tests
- static and transient `.git` redirection tests while Git executes
- `.git` file/symlink; system executable symlink/owner/mode cases for Git and Darwin Python
- Linux direct-proc-FD/no-helper and Darwin fixed-helper/PATH/argv-isolation tests
- complete index fence matrix: add/modify/delete, stages 1/2/3, mode, foreign, duplicate
- directory/FIFO/socket/device/hardlink, root/parent/target symlink, oversize, short-read, growth, read error, target and parent swap tests
- complete publisher-signal, HEAD-change, partial-generation, and root-replacement evidence matrix
- root replacement is swapped back after every Git call and compares exact NUL tree/index bytes plus distinct original/replacement blobs
- expanded public purity gate forbids write syscalls, Path/tempfile/flock, network, wall clock, mutating Git, and ServiceRegistry import

Updated local gates: 138 D1/D2a tests passed with 2 platform-opposite skips; 9 directly affected contract tests passed; full Ruff format/lint and changed-scope Bandit passed.


## Final parent-race fix (`6af68612`)

- parent fingerprint now includes both the repository root FD and optional `.steward` FD
- adds the exact dirty-root-target / HEAD-identical-inode swap attack: stable across both reads, restored immediately after the second read, and classified `manual_review` with a race indicator
- root-replacement FD evidence still compares complete original-vs-replacement NUL tree/index bytes and distinct blobs; parent drift is now fail-closed instead of being classified as legacy
