### PR TITLE
docs: heartbeat failure-propagation feature-spec DRAFT 0.3 (adversarial review incorporated)

### DIFF
--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
@@ -2,9 +2,9 @@
 
 ## Sichtbarmachung anhaltenden kognitiven/Provider-Kollaps
 
-> **Status:** DRAFT 0.5 — SCHNITT A AUSFÜHRBAR; DREI ADVERSARIAL-REVIEW-RUNDEN EINGEARBEITET
-> (invertiertes Prädikat + Skip-Kollaps-Blindfleck); NICHT G1; IMPLEMENTIERUNG UND
-> AKTIVIERUNG GESPERRT
+> **Status:** DRAFT 0.6 — VIER ADVERSARIAL-REVIEW-RUNDEN; NORMATIVER KERN §5.3 HAT ZWEI
+> BENANNTE, TRAGENDE LÜCKEN (§10.4: vibe_core-Dekodierung + Per-Provider-Quota-Datenlücke) —
+> NICHT G1, NICHT HAIKU-IMPLEMENTIERBAR, bis §10.4 aufgelöst ist. IMPL./AKTIVIERUNG GESPERRT
 > **Datum:** 2026-07-17
 > **Produktionsbasis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
 > **Herkunft:** Phase-2 §7.3; Recon RECON_01–04; adversariales Review (§12)
@@ -77,7 +77,8 @@ Pro MOKSHA-Zyklus aus `stats()`: `providers_alive`, `providers_total`, `total_ca
   Quota erschöpft `chamber.py:244`, Breaker OPEN `:251`, Membran zu schwach `:255` — jeweils
   `continue` **ohne** `_record_call_failure`, also `fd=0`). `providers_usable` = pro Provider
   `alive AND breaker≠OPEN AND within_quota`, ableitbar aus `stats()` (Felder `alive`,
-  `breaker`, chamber-`quota`). Fängt das schwerste Krankheitsbild — Quota-Erschöpfung über
+  `breaker`, chamber-`quota`) — **aber die Per-Provider-Quota fehlt heute in `stats()`, siehe
+  §10.4b (offene Operator-Entscheidung).** Zielt auf das schwerste Krankheitsbild — Quota-Erschöpfung über
   einen Tag (RECON_04) und den vertieften Breaker-Steady-State —, das `degraded` (braucht
   `fd>0`) systematisch verfehlt.
 
@@ -213,18 +214,45 @@ None-Guard (Befund 6).
 2. Prädikat-Wahl für C (Hard-Down / Degradation / kombiniert) — aus A-Daten.
 3. Atomicity des Health-Writes — **jetzt als C-Blocker (iii) §8 verdrahtet** (Befund 2), nicht
    mehr nur „separate Hygiene".
-4. **vibe_core-Statusformen pinnen (Runde 3):** die exakte Dekodierung von `p['breaker']`
-   (get_status → wann OPEN), `ps['quota']` (wann erschöpft) und `MahaCellUnified.is_alive`
-   liegt in `vibe_core` (hier nicht installiert). `providers_usable`/`skip_collapse` und der
-   `hard_down`-Backstop hängen daran — vor Implementierung gegen die echten Formen pinnen,
-   **nicht raten** (das war die Fehlerklasse der Runden 2/3). Die Helfer `_breaker_ok`/
-   `_quota_ok` in §5.3 sind Platzhalter für genau diese Dekodierung.
+4. **NORMATIVE KERN-LÜCKE — §5.3 ist bis hierhin NICHT ausführbar.** Zwei getrennte Teile:
+
+   **4a — Dekodierung (Runde 3):** `_breaker_ok(p['breaker'])`, `is_alive` und der globale
+   `ps['quota']`-Status liegen in `vibe_core` (hier nicht installiert). Exakte Formen (wann
+   „OPEN", wann „erschöpft") vor Implementierung gegen den echten `get_status()` pinnen,
+   **nicht raten**. `_breaker_ok`/`_quota_ok` in §5.3 sind Platzhalter dafür.
+
+   **4b — Per-Provider-Quota ist eine DATENLÜCKE, kein Dekodier-Problem (Runde 4, HIGH):**
+   Der Skip-Pfad, den `skip_collapse` adressiert (`chamber.py:244`), nutzt
+   `_is_within_quota(payload)` (`chamber.py:514–520`) und liest **Per-Provider**-Felder
+   `payload.calls_today`/`daily_call_limit`/`tokens_today`. **Keines** steht in `stats()`
+   (Per-Provider-Dict `chamber.py:426–435`: nur name/model/prana/integrity/cycle/alive/
+   breaker). Der globale `self._quota.get_status()` deckt nur den Streaming-Gate
+   (`chamber.py:337`), **nicht** den Per-Provider-Skip `:244`. ⇒ `providers_usable` bleibt
+   bei erschöpfter Free-Tier-Tagesquota strukturell >0 → `skip_collapse=False` → A blind
+   für genau das Runde-3-Krankheitsbild. `test_skip_collapse_quota` (global geformt) wäre
+   grün, die Produktion blind — §220.3-Modus.
+
+   **Operator-Entscheidung nötig (eine muss die Spec wählen):**
+   - **(a)** `stats()` um Per-Provider-Quota erweitern (`calls_today`/`daily_call_limit`) —
+     das ist eine `chamber.py`-Änderung und **verletzt den aktuellen Non-Scope** (§4, „nur
+     `moksha_health.py`"). Bewusstes Re-Scope. Macht A für sein Kernkrankheitsbild sehend.
+   - **(b)** Per-Provider-Quota-Skip als akzeptierten **Blindfleck** von A dokumentieren →
+     C darf dann **keine** Quota-Schwelle aus A-Daten ableiten. Hält A minimal, entwertet
+     aber A für den Hauptfall.
 
 ## 11. Schlussstatus
 
-DRAFT 0.5. Schnitt A misst Hard-Down, Degradation UND Skip-Kollaps; B/C korrekt gegated.
-Einzige tragende ungeprüfte Annahme: die vibe_core-Statusformen (§10.4). Kein G1, keine
-Implementierung, keine Aktivierung ohne erneutes Review von §5/§6/§8 und Operator-Go.
+DRAFT 0.6. Schnitt A misst Hard-Down, Degradation und Skip-Kollaps; B/C korrekt gegated.
+**Nicht ausführbar/Haiku-tauglich, bis §10.4 aufgelöst ist:** (4a) vibe_core-Dekodierung
+pinnen [braucht vibe_core-Umgebung]; (4b) Per-Provider-Quota-Datenlücke per Operator-
+Entscheidung (a)/(b) auflösen. Danach ist G1 plausibel. Kein G1/Impl./Aktivierung ohne beides
++ erneutes Review + Operator-Go.
+
+**Minor (für den C-Designer):** `skip_collapse` ist ein **Kapazitäts**-Prädikat („könnten
+wir kognizieren?"), in denselben Streak gefaltet wie die **Failure**-Prädikate
+`degraded`/`hard_down` („versucht und gescheitert?"). `skip_collapse` kann bei null Nachfrage
+feuern (Breaker transient offen, aber der Zyklus wollte keine Kognition) — ein Streak-
+Inkrement heißt also nicht immer „Kognition scheiterte".
 
 ## 12. Review-Historie
 
@@ -252,3 +280,13 @@ Implementierung, keine Aktivierung ohne erneutes Review von §5/§6/§8 und Oper
   Fix: neuer Zustand `skip_collapse = providers_usable==0` (§5); Test `test_skip_collapse_quota`
   (§6); vibe_core-Statusformen als Pin-Pflicht §10.4. `is_alive` bleibt die einzige
   ungeprüfte tragende Annahme (vibe_core nicht installiert). G1 weiterhin verwehrt.
+- **Vierte Runde (2026-07-17, Review von DRAFT 0.5):** 1 neuer HIGH-Befund — der normative
+  Kern §5.3 ist nicht ausführbar (undefinierte `_breaker_ok`/`_quota_ok` → Haiku müsste
+  raten). Und tiefer: der Per-Provider-Quota-Skip (`chamber.py:244`, `_is_within_quota` liest
+  `payload.calls_today`/`daily_call_limit`, `:514–520`) ist eine **Datenlücke** — diese
+  Felder stehen nicht in `stats()` (`:426–435`); der globale `_quota` deckt nur den
+  Streaming-Gate `:337`. Am Code verifiziert. `skip_collapse` ist damit für sein
+  Hauptkrankheitsbild (Free-Tier-Quota) blind, `test_skip_collapse_quota` wäre grün bei
+  blinder Produktion (§220.3). §10.4 neu gerahmt (4a Dekodierung / 4b Datenlücke) mit
+  expliziter Operator-Entscheidung (a) `stats()` erweitern [Re-Scope] vs. (b) Blindfleck
+  dokumentieren. Minor (Kapazität- vs. Failure-Prädikat) in §11 für C notiert. G1 verwehrt.

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
@@ -2,9 +2,10 @@
 
 ## Sichtbarmachung anhaltenden kognitiven/Provider-Kollaps
 
-> **Status:** DRAFT 0.6 — VIER ADVERSARIAL-REVIEW-RUNDEN; NORMATIVER KERN §5.3 HAT ZWEI
-> BENANNTE, TRAGENDE LÜCKEN (§10.4: vibe_core-Dekodierung + Per-Provider-Quota-Datenlücke) —
-> NICHT G1, NICHT HAIKU-IMPLEMENTIERBAR, bis §10.4 aufgelöst ist. IMPL./AKTIVIERUNG GESPERRT
+> **Status:** DRAFT 0.7 — FÜNF ADVERSARIAL-REVIEW-RUNDEN. 4b (Per-Provider-Quota) als TOTER
+> PFAD aufgelöst; einzige verbleibende tragende Lücke ist §10.4a (vibe_core-Statusdekodierung).
+> NICHT G1 / nicht Haiku-implementierbar, bis 4a in einer vibe_core-Umgebung gepinnt ist.
+> IMPL./AKTIVIERUNG GESPERRT
 > **Datum:** 2026-07-17
 > **Produktionsbasis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
 > **Herkunft:** Phase-2 §7.3; Recon RECON_01–04; adversariales Review (§12)
@@ -76,9 +77,10 @@ Pro MOKSHA-Zyklus aus `stats()`: `providers_alive`, `providers_total`, `total_ca
 - `skip_collapse` = `providers_usable==0` (alle Provider **übersprungen** statt versucht:
   Quota erschöpft `chamber.py:244`, Breaker OPEN `:251`, Membran zu schwach `:255` — jeweils
   `continue` **ohne** `_record_call_failure`, also `fd=0`). `providers_usable` = pro Provider
-  `alive AND breaker≠OPEN AND within_quota`, ableitbar aus `stats()` (Felder `alive`,
-  `breaker`, chamber-`quota`) — **aber die Per-Provider-Quota fehlt heute in `stats()`, siehe
-  §10.4b (offene Operator-Entscheidung).** Zielt auf das schwerste Krankheitsbild — Quota-Erschöpfung über
+  `alive AND breaker≠OPEN AND within_quota(global)`, ableitbar aus `stats()` (Felder `alive`,
+  `breaker`, globaler `quota`). Lebende Eingänge: Breaker-OPEN, Membran, globale Quota. Der
+  Per-Provider-Quota-Skip (`:244`) ist toter Pfad (§10.4b), also keine Datenlücke. Zielt auf
+  das schwerste Krankheitsbild — Quota-Erschöpfung über
   einen Tag (RECON_04) und den vertieften Breaker-Steady-State —, das `degraded` (braucht
   `fd>0`) systematisch verfehlt.
 
@@ -165,10 +167,11 @@ Builder-Ebene:
   → `collapsed False`, `consecutive_collapsed_cycles==0` trotz `prev.streak=5`.
 - `test_no_provider_registered`: SVC_PROVIDER fehlt → Block mit `providers_total==0`,
   Streak == `prev.streak`; kein Fehler.
-- `test_skip_collapse_quota` (**Runde 3**): alle Provider im Skip-Zustand (über Quota bzw.
-  Breaker OPEN, via passend geformtem `breaker`/`quota`-Status), `cd==0, fd==0`, aber
-  `providers_usable==0` → `skip_collapse True`, Streak +1. Fängt den Quota-/Breaker-
-  Blindfleck, den `degraded` allein verfehlt.
+- `test_skip_collapse_breaker` (**Runde 3/5, lebender Pfad**): alle Provider mit Breaker
+  OPEN (echter Zustand über die 4a-gepinnte Statusform), `cd==0, fd==0`, aber
+  `providers_usable==0` → `skip_collapse True`, Streak +1. Treibt den **erreichbaren**
+  Skip-Pfad (`chamber.py:251`), nicht die tote Per-Provider-Quota-Form (`:244`) — sonst
+  „grüner Test, tote Produktion" (§220.3).
 
 Disk-Roundtrip-Ebene (**das eigentliche Novum — Befund 3**):
 - `test_roundtrip_increment`: Datei mit `cognition.consecutive_collapsed_cycles=N` +
@@ -221,32 +224,36 @@ None-Guard (Befund 6).
    „OPEN", wann „erschöpft") vor Implementierung gegen den echten `get_status()` pinnen,
    **nicht raten**. `_breaker_ok`/`_quota_ok` in §5.3 sind Platzhalter dafür.
 
-   **4b — Per-Provider-Quota ist eine DATENLÜCKE, kein Dekodier-Problem (Runde 4, HIGH):**
-   Der Skip-Pfad, den `skip_collapse` adressiert (`chamber.py:244`), nutzt
-   `_is_within_quota(payload)` (`chamber.py:514–520`) und liest **Per-Provider**-Felder
-   `payload.calls_today`/`daily_call_limit`/`tokens_today`. **Keines** steht in `stats()`
-   (Per-Provider-Dict `chamber.py:426–435`: nur name/model/prana/integrity/cycle/alive/
-   breaker). Der globale `self._quota.get_status()` deckt nur den Streaming-Gate
-   (`chamber.py:337`), **nicht** den Per-Provider-Skip `:244`. ⇒ `providers_usable` bleibt
-   bei erschöpfter Free-Tier-Tagesquota strukturell >0 → `skip_collapse=False` → A blind
-   für genau das Runde-3-Krankheitsbild. `test_skip_collapse_quota` (global geformt) wäre
-   grün, die Produktion blind — §220.3-Modus.
+   **4b — AUFGELÖST (Runde 5): der Per-Provider-Quota-Skip `:244` ist ein TOTER PFAD.**
+   Runde 4 rahmte dies als Datenlücke + Operator-Entscheidung. Am Code widerlegt: der Skip
+   `chamber.py:244` prüft `_is_within_quota(payload)`, das `payload.calls_today`/`tokens_today`
+   liest (`chamber.py:516/518`). Diese Zähler sind als `0` definiert (`chamber.py:80/81`) und
+   werden **nirgends im Repo inkrementiert** (verifiziert: null Writer; `_record_call_success`
+   aktualisiert die globale `self._quota`, nicht `payload.calls_today`). ⇒ `_is_within_quota`
+   liefert immer `True` ⇒ `:244` kann nicht feuern. **Keine reale Abdeckung geht verloren,
+   und es gibt keine (a)/(b)-Entscheidung mehr.** Die Limits sind zwar gesetzt
+   (`build_chamber` 1000/2880/1000, `:129/148/169`) — Budget beabsichtigt, nur nie verdrahtet.
 
-   **Operator-Entscheidung nötig (eine muss die Spec wählen):**
-   - **(a)** `stats()` um Per-Provider-Quota erweitern (`calls_today`/`daily_call_limit`) —
-     das ist eine `chamber.py`-Änderung und **verletzt den aktuellen Non-Scope** (§4, „nur
-     `moksha_health.py`"). Bewusstes Re-Scope. Macht A für sein Kernkrankheitsbild sehend.
-   - **(b)** Per-Provider-Quota-Skip als akzeptierten **Blindfleck** von A dokumentieren →
-     C darf dann **keine** Quota-Schwelle aus A-Daten ableiten. Hält A minimal, entwertet
-     aber A für den Hauptfall.
+   **Latent-Feature-Guard (macht die Spec zukunftsfest):** *Wird `payload.calls_today` je
+   inkrementiert, wird `:244` lebendig und 4b eine echte Per-Provider-Datenlücke — dann
+   `skip_collapse` erneut prüfen (Feld in `stats()` exponieren oder Blindfleck bewusst
+   tragen).*
+
+   **Lebende `skip_collapse`-Eingänge** sind damit: Breaker-OPEN (`:251`), schwache Membran
+   (`:255`) und **globale** Quota-Erschöpfung (`self._quota.check_before_request` am Kopf von
+   `invoke()`, `chamber.py:231–238`, `return None`). Alle drei sind aus `stats()` (`breaker`,
+   `integrity`/`alive`, globaler `quota`) unter 4a rekonstruierbar — 4b kollabiert in 4a.
+   *Hinweis:* Reviewer-Runde-5-Punkt „`_quota_ok` sei Streaming-only tot" ist am Code
+   widerlegt — der globale Quota-Check steht auch im non-streaming `invoke()` (`:231`), also
+   bleibt `_quota_ok` erreichbar und normativ.
 
 ## 11. Schlussstatus
 
-DRAFT 0.6. Schnitt A misst Hard-Down, Degradation und Skip-Kollaps; B/C korrekt gegated.
-**Nicht ausführbar/Haiku-tauglich, bis §10.4 aufgelöst ist:** (4a) vibe_core-Dekodierung
-pinnen [braucht vibe_core-Umgebung]; (4b) Per-Provider-Quota-Datenlücke per Operator-
-Entscheidung (a)/(b) auflösen. Danach ist G1 plausibel. Kein G1/Impl./Aktivierung ohne beides
-+ erneutes Review + Operator-Go.
+DRAFT 0.7. Schnitt A misst Hard-Down, Degradation und Skip-Kollaps; B/C korrekt gegated.
+**Einziger verbleibender G1-Blocker: §10.4a** — die vibe_core-Statusdekodierung
+(`_breaker_ok`/`_quota_ok`/`is_alive`), zu pinnen in einer Umgebung *mit* `vibe_core`; dieses
+Environment kann es nicht. Danach ist G1 plausibel. Kein G1/Impl./Aktivierung ohne 4a +
+erneutes Review + Operator-Go.
 
 **Minor (für den C-Designer):** `skip_collapse` ist ein **Kapazitäts**-Prädikat („könnten
 wir kognizieren?"), in denselben Streak gefaltet wie die **Failure**-Prädikate
@@ -290,3 +297,12 @@ Inkrement heißt also nicht immer „Kognition scheiterte".
   blinder Produktion (§220.3). §10.4 neu gerahmt (4a Dekodierung / 4b Datenlücke) mit
   expliziter Operator-Entscheidung (a) `stats()` erweitern [Re-Scope] vs. (b) Blindfleck
   dokumentieren. Minor (Kapazität- vs. Failure-Prädikat) in §11 für C notiert. G1 verwehrt.
+- **Fünfte Runde (2026-07-17, Review von DRAFT 0.6):** Runde 4 teilweise **entkräftet** — der
+  Per-Provider-Quota-Skip `:244` ist ein **toter Pfad**: `payload.calls_today` wird nirgends
+  inkrementiert (verifiziert: null Writer; def `=0` `chamber.py:80/81`), `_is_within_quota`
+  ist immer `True`. Also keine Operator-Entscheidung (a)/(b) — 4b aufgelöst, kollabiert in 4a.
+  Gegenprobe zu Reviewer-Punkt 3: der globale Quota-Check sitzt **auch** im non-streaming
+  `invoke()` (`chamber.py:231–238`), nicht nur Streaming → `_quota_ok` bleibt erreichbar/
+  normativ (Reviewer hier am Code widerlegt). Folgen: §10.4b neu (toter Pfad + Latent-Guard),
+  §5.1 präzisiert, `test_skip_collapse_quota` → `test_skip_collapse_breaker` (lebender Pfad).
+  Einziger G1-Blocker bleibt §10.4a (vibe_core-Dekodierung). G1 verwehrt.

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
@@ -2,23 +2,21 @@
 
 ## Sichtbarmachung anhaltenden kognitiven/Provider-Kollaps
 
-> **Status:** DRAFT 0.2 — SCHNITT A AUSFÜHRBAR SPEZIFIZIERT; NICHT G1; IMPLEMENTIERUNG UND
-> AKTIVIERUNG GESPERRT
+> **Status:** DRAFT 0.3 — SCHNITT A AUSFÜHRBAR; ADVERSARIAL-REVIEW-BEFUNDE 1–6 EINGEARBEITET;
+> NICHT G1; IMPLEMENTIERUNG UND AKTIVIERUNG GESPERRT
 > **Datum:** 2026-07-17
 > **Produktionsbasis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
-> **Herkunft:** Phase-2 §7.3; Recon RECON_01–04 in `heartbeat_failure_propagation_evidence/`
+> **Herkunft:** Phase-2 §7.3; Recon RECON_01–04; adversariales Review (§12)
 
 ---
 
 ## 1. Zweck und Gate
 
-Anhaltenden kognitiven/Provider-Kollaps beobachtbar machen, ohne die bewusste Resilienz
-(Daemon stirbt nicht an transienten Fehlern) zu brechen. LOGGING zuerst; Erzwingen (Run rot)
-erst nach belegter Beobachtung und nur hinter Kill-Switch.
-
-DRAFT. Kein G1 ohne adversariales Review (§10) und Operator-Go. **Schnitt A** ist hier so
-spezifiziert, dass er ohne Interpretationsspielraum umsetzbar ist. **Schnitt B/C** sind
-bewusst datengesteuert gegated (nicht geraten).
+Anhaltenden kognitiven/Provider-Kollaps beobachtbar machen, ohne die bewusste Resilienz zu
+brechen. LOGGING zuerst; Erzwingen (Run rot) erst nach belegter Beobachtung, nur hinter
+Kill-Switch. DRAFT — kein G1 ohne Auflösung der offenen Blocker (§12) und Operator-Go.
+**Schnitt A** ist ohne Interpretationsspielraum spezifiziert; **B/C** sind datengesteuert
+gegated.
 
 ## 2. Normative Abhängigkeiten
 
@@ -28,114 +26,137 @@ Produktionsbasis oben und sind vor Implementierung erneut zu pinnen.
 ## 3. Gepinnte Fakten (belegt, mit Anker)
 
 - `chamber.stats()` → `chamber.py:423`; liefert `{"providers":[{"name","alive",…}],
-  "total_calls":int, "total_failures":int, …}`.
-- Chamber ist Service: Klasse `SVC_PROVIDER` `services.py:40`; Registrierung
-  `services.py:285` (`ServiceRegistry.register(SVC_PROVIDER, provider)`); Get-Muster wie
-  `context_bridge.py:271` (`ServiceRegistry.get(SVC_PROVIDER)`).
-- Health-Report-Builder `_build_health_report()` `moksha_health.py:62`; Writer/Execute
-  `moksha_health.py:39–59`; Zieldateien `.steward/federation_health.json` und
-  `data/federation/steward_health.json` (plain `write_text`, **nicht** atomar).
-- Health-Hook registriert: `hooks/__init__.py:66` (`MokshaHealthReportHook`). Läuft pro
-  MOKSHA-Zyklus.
-- **Kein** Once-per-Run/Shutdown-Phasen-Hook (bestätigt); nur Per-Zyklus-Hooks. Prozess-
-  `close()` `agent.py:742` ist kein Phasen-Hook → nicht genutzt. ⇒ Streak-Granularität =
-  **pro Zyklus**.
-- `.steward/federation_health.json` wird vom Heartbeat committet (`steward-heartbeat.yml:99`
-  `git add -u -- .steward/`) ⇒ über Runs persistent.
+  "total_calls":int, "total_failures":int, …}`. `total_calls`/`total_failures` sind
+  prozess-monoton (nur bei frischem Prozess auf 0; `_maybe_reset_daily` `chamber.py:522`
+  setzt sie **nicht** zurück).
+- Chamber ist Service: `SVC_PROVIDER` `services.py:40`; Registrierung `services.py:285`;
+  Get-Muster `context_bridge.py:271`.
+- Health-Builder `_build_health_report()` `moksha_health.py:62`; Writer `moksha_health.py:
+  39–59`; Dateien `.steward/federation_health.json` + `data/federation/steward_health.json`
+  (plain `write_text`, **nicht atomar**). Beide git-tracked, per `steward-heartbeat.yml:99`
+  committet ⇒ über Runs persistent (unabhängig verifiziert im Review §12).
+- Health-Hook registriert `hooks/__init__.py:66`; läuft pro MOKSHA-Zyklus.
+- **Kein** Once-per-Run-Hook (bestätigt) ⇒ Streak-Granularität = **pro Zyklus**.
+- Erkennung existiert: `vedana.py:78` (`_W_PROVIDER=0.35`, höchstes Gewicht) →
+  `dharma.py:56–57` (`health<0.3` → `health_anomaly`); Konsum nur `engine.py:310`.
 
 ## 4. Scope und Nicht-Scope
 
-**In Scope (Schnitt A):** ein `cognition`-Block im vorhandenen Health-Report inkl. eines über
-Runs persistierten Zyklus-Streak-Zählers. **Kein** Einfluss auf Run-Exit-Status.
+**In Scope (Schnitt A):** ein `cognition`-Instrument-Block im vorhandenen Health-Report, der
+sowohl Hard-Down als auch **Degradation** (Zyklus-Delta) misst und über Runs persistiert.
+Kein Einfluss auf Run-Exit-Status.
 
 **Nicht-Scope:** kein `raise` in `chamber`; keine Änderung der Workflow-`try/except`-
-Resilienz; keine Atomicity-Änderung am bestehenden Health-Write (vorbestehend, eigener
-Hygiene-Punkt); Context-Bridge/Identität/Rotation/Quarantäne unberührt. Kein Sammelpatch.
+Resilienz; Context-Bridge/Identität/Rotation/Quarantäne unberührt. Kein Sammelpatch. Die
+Atomicity des Health-Writes wird in A nicht geändert, ist aber **C-Blocker** (§8).
 
-## 5. SCHNITT A — AUSFÜHRBARER VERTRAG (Sichtbarkeit)
+## 5. SCHNITT A — AUSFÜHRBARER VERTRAG (Instrument, nicht nur Hard-Down)
 
-### 5.1 Kollaps-Prädikat (rein aus `stats()`, kein Delta)
-```
-pstats = ServiceRegistry.get(SVC_PROVIDER).stats()
-providers = pstats["providers"]
-alive  = sum(1 for p in providers if p.get("alive"))
-total  = len(providers)
-collapsed = (total > 0 and alive == 0)
-```
+> **Behebt Review-Befund 1:** A misst nicht nur `alive==0`, sondern die real beobachtete
+> Degradation (Zyklus lief, keine Kognition gelang). Nur so entstehen die Daten, die C's
+> Schwelle begründen sollen.
 
-### 5.2 Persistierter Zyklus-Streak (Lesen-vor-Überschreiben)
-Vor dem Überschreiben den vorherigen Streak aus der bestehenden Zieldatei lesen:
+### 5.1 Beobachtete Rohgrößen (illustrativ; **normativ ist allein §5.3**)
+Pro MOKSHA-Zyklus aus `stats()`: `providers_alive`, `providers_total`, `total_calls`,
+`total_failures`. Abgeleitet über den Zyklus-Delta zum vorigen Report: `calls_delta`,
+`fail_delta`. Zwei Zustände:
+- `hard_down` = `providers_total>0 and providers_alive==0` (Total-Ausfall, Momentwert).
+- `degraded` = `calls_delta>0 and fail_delta>=calls_delta` (im Zyklus wurde Kognition
+  versucht, **keine** gelang) — dies ist das Krankheitsbild aus RECON_01 §4.
+
+`collapsed = hard_down or degraded` treibt **einen** Streak.
+
+### 5.2 Lesen-vor-Überschreiben (**nur Extraktion**, kein Rechnen — Befund 4)
 ```
-prev = 0
+prev = {"consecutive_collapsed_cycles": 0, "total_calls": 0, "total_failures": 0}
 try:
-    prev = json.loads(Path(".steward/federation_health.json").read_text())\
-             .get("cognition", {}).get("consecutive_collapsed_cycles", 0)
-except (OSError, ValueError):
-    prev = 0
-streak = prev + 1 if collapsed else 0
+    _c = json.loads(Path(".steward/federation_health.json").read_text()).get("cognition", {})
+    prev["consecutive_collapsed_cycles"] = _c.get("consecutive_collapsed_cycles", 0)
+    prev["total_calls"]    = _c.get("total_calls", 0)
+    prev["total_failures"] = _c.get("total_failures", 0)
+except (OSError, ValueError, TypeError):
+    pass   # fehlende/zerrissene Datei ⇒ Defaults (für A tolerierbar; C-Blocker §8)
 ```
+`execute()` übergibt `prev` an den Builder. `execute()` selbst **inkrementiert nicht**.
 
-### 5.3 Report-Erweiterung
-`_build_health_report()` (`moksha_health.py:62`) erhält Signatur
-`_build_health_report(prev_streak: int = 0)` und ergänzt vor `return report`:
+### 5.3 Report-Erweiterung (**einzige Inkrement-Stelle** — Befund 4, mit None-Guard — Befund 6)
+`_build_health_report(prev: dict | None = None)` (`moksha_health.py:62`) ergänzt vor
+`return report`:
 ```
+prev = prev or {"consecutive_collapsed_cycles": 0, "total_calls": 0, "total_failures": 0}
+cog = {"providers_alive": 0, "providers_total": 0, "total_calls": 0, "total_failures": 0,
+       "calls_delta": 0, "fail_delta": 0, "hard_down": False, "degraded": False,
+       "consecutive_collapsed_cycles": prev["consecutive_collapsed_cycles"]}
 provider = ServiceRegistry.get(SVC_PROVIDER)
-report["cognition"] = {"providers_alive": 0, "providers_total": 0,
-                       "total_calls": 0, "total_failures": 0,
-                       "collapsed": False, "consecutive_collapsed_cycles": prev_streak}
 if provider is not None and hasattr(provider, "stats"):
-    ps = provider.stats()
-    providers = ps.get("providers", [])
-    alive = sum(1 for p in providers if p.get("alive"))
-    total = len(providers)
-    collapsed = (total > 0 and alive == 0)
-    report["cognition"] = {
-        "providers_alive": alive, "providers_total": total,
-        "total_calls": ps.get("total_calls", 0),
-        "total_failures": ps.get("total_failures", 0),
-        "collapsed": collapsed,
-        "consecutive_collapsed_cycles": (prev_streak + 1 if collapsed else 0),
-    }
+    ps = provider.stats(); providers = ps.get("providers", [])
+    alive = sum(1 for p in providers if p.get("alive")); total = len(providers)
+    tc = ps.get("total_calls", 0); tf = ps.get("total_failures", 0)
+    # Run-Grenze: frischer Prozess setzt Totals auf 0 -> Delta = aktuelle Totals
+    if tc >= prev["total_calls"]:
+        cd = tc - prev["total_calls"]; fd = tf - prev["total_failures"]
+    else:
+        cd = tc; fd = tf
+    hard_down = (total > 0 and alive == 0)
+    degraded  = (cd > 0 and fd >= cd)
+    collapsed = hard_down or degraded
+    cog.update({"providers_alive": alive, "providers_total": total,
+                "total_calls": tc, "total_failures": tf,
+                "calls_delta": cd, "fail_delta": fd,
+                "hard_down": hard_down, "degraded": degraded,
+                "consecutive_collapsed_cycles":
+                    prev["consecutive_collapsed_cycles"] + 1 if collapsed else 0})
+report["cognition"] = cog
 ```
-`execute()` (`moksha_health.py:39`) liest `prev` (5.2) und ruft
-`_build_health_report(prev_streak=prev)`. Writer und Dateien **unverändert**.
 
 ### 5.4 Invariante
-Schnitt A ändert **keinen** Kontrollfluss außerhalb `moksha_health.py`, wirft nicht, ändert
-den Run-Exit-Status in **keinem** Fall. Nur ein zusätzliches Datenfeld.
+Schnitt A ändert **keinen** Kontrollfluss außerhalb `moksha_health.py`, wirft nicht (der
+`get(SVC_PROVIDER)`-None-Fall ist geführt), ändert den Run-Exit-Status in **keinem** Fall.
 
-## 6. SCHNITT A — TESTVERTRAG (exakt, echte Klassen, kein Stub)
+## 6. SCHNITT A — TESTVERTRAG (exakt, echte Klassen; inkl. Disk-Roundtrip — Befund 3)
 
-Datei `tests/test_moksha_health.py` (neu oder erweitert). Gegen echte `ProviderChamber`
-(`build_chamber()`-artig konstruiert), via `ServiceRegistry.register(SVC_PROVIDER, chamber)`.
+Datei `tests/test_moksha_health.py`. Gegen echte `ProviderChamber`, via
+`ServiceRegistry.register(SVC_PROVIDER, chamber)`. Dateibasierte Tests nutzen ein `tmp_path`
+als cwd.
 
-- `test_cognition_block_present_and_healthy`: 2 lebende Cells → `report["cognition"]`
-  existiert; `providers_total == 2`; `providers_alive == 2`; `collapsed is False`;
-  `consecutive_collapsed_cycles == 0`.
-- `test_collapse_increments_streak`: alle Cells nicht-alive → `collapsed is True`;
-  `_build_health_report(prev_streak=3)` ⇒ `consecutive_collapsed_cycles == 4`.
-- `test_transient_resets_streak` (**Guard §220.3**): ≥1 lebende Cell, `prev_streak=5`
-  ⇒ `collapsed is False`; `consecutive_collapsed_cycles == 0`.
-- `test_no_provider_registered`: SVC_PROVIDER nicht registriert ⇒ `cognition`-Block mit
-  `providers_total == 0`, `consecutive_collapsed_cycles == prev_streak`; kein Fehler.
+Builder-Ebene:
+- `test_cognition_block_healthy`: 2 lebende Cells, `prev` leer → `providers_alive==2`,
+  `hard_down False`, `degraded False`, `consecutive_collapsed_cycles==0`.
+- `test_hard_down_increments`: alle Cells nicht-alive, `prev.streak=3` → `hard_down True`,
+  `consecutive_collapsed_cycles==4`.
+- `test_degraded_increments` (**Befund 1**): Cells alive, aber `prev.total_calls`/
+  `total_failures` so gesetzt, dass `calls_delta>0 and fail_delta==calls_delta` → `degraded
+  True`, Streak +1 — obwohl `hard_down False`.
+- `test_transient_resets` (**Guard §220.3**): ≥1 Erfolg im Zyklus (`fail_delta<calls_delta`)
+  → `collapsed False`, `consecutive_collapsed_cycles==0` trotz `prev.streak=5`.
+- `test_no_provider_registered`: SVC_PROVIDER fehlt → Block mit `providers_total==0`,
+  Streak == `prev.streak`; kein Fehler.
+
+Disk-Roundtrip-Ebene (**das eigentliche Novum — Befund 3**):
+- `test_roundtrip_increment`: Datei mit `cognition.consecutive_collapsed_cycles=N` +
+  passenden Totals schreiben → `execute()` bei Kollaps → **Datei zeigt `N+1`**.
+- `test_roundtrip_missing_and_torn`: Datei fehlt / enthält torn JSON / hat keinen
+  `cognition`-Key → `prev`-Defaults, kein Crash, Run-Ausgang unverändert.
 - `test_execute_appends_ok_and_returns_none`: `execute(ctx)` gibt `None`, hängt
-  `"moksha_health_report:ok"` an `ctx.operations` an, wirft nicht (Invariante 5.4).
+  `"moksha_health_report:ok"` an, wirft nicht.
 
 ## 7. SCHNITT A — AKZEPTANZ (Produktionslog, nicht grüner Test)
 
-Nach einem Heartbeat-Run gilt: `.steward/federation_health.json` enthält den `cognition`-
-Block mit den sechs Feldern; bei lebenden Providern `consecutive_collapsed_cycles: 0`; der
-Run-Exit-Status ist unverändert grün. Verifikation am realen Artefakt + Run-Log.
+Nach einem Heartbeat-Run enthält `.steward/federation_health.json` den `cognition`-Block mit
+allen Feldern (inkl. `calls_delta`/`fail_delta`/`degraded`); bei gesunder Kognition
+`consecutive_collapsed_cycles: 0`; Run-Exit-Status unverändert grün. Verifikation am realen
+Artefakt über mehrere aufeinanderfolgende Runs (Streak-Verhalten sichtbar).
 
-## 8. SCHNITT B/C — PRÄZISE GEGATED (nicht geraten)
+## 8. SCHNITT B/C — PRÄZISE GEGATED
 
-- **B (Eskalation):** erst nachdem A in Produktion Daten geliefert hat. Wiederverwendung des
-  vorhandenen Issue-Musters (`dharma.py:187`, heute Peer-scoped) für Selbst-Kollaps. Eigene
-  G2-Spec. Ändert Run-Ausgang **nicht**.
-- **C (Erzwingen/Run-rot):** GESPERRT bis (i) A-Beobachtung die Schwelle `N`
-  (`consecutive_collapsed_cycles ≥ N`) empirisch begründet und (ii) das Prädikat (5.1)
-  ggf. auf „keine erfolgreiche Kognition" verschärft ist. Hinter Feature-Flag/Kill-Switch,
-  Default AUS. Eigene G2-Spec + Operator-Go.
+- **B (Eskalation):** erst nach A-Produktionsdaten. Wiederverwendung `dharma.py:187`
+  (Peer-Muster) für Selbst-Kollaps. Eigene G2-Spec. Kein Run-Rot.
+- **C (Erzwingen/Run-rot):** GESPERRT bis **alle drei**:
+  (i) A-Beobachtung begründet die Schwelle `N` empirisch (§10.1, Einheit Zyklen);
+  (ii) Prädikat für C entschieden (Hard-Down vs. Degradation vs. Kombination);
+  (iii) **Atomarer Persistenz-Write** hergestellt (Befund 2) — eine Rot-Schwelle darf nicht
+  auf einem Zähler ruhen, dessen Datei genau bei Crash/Unhealth still auf 0 resettet.
+  Hinter Feature-Flag/Kill-Switch, Default AUS. Eigene G2-Spec + Operator-Go.
 
 ## 9. Rollback
 
@@ -144,20 +165,30 @@ kein Kontrollfluss.
 
 ## 10. Offene Fragen
 
-**Geschlossen durch DRAFT 0.2:** Chamber-Erreichbarkeit (SVC_PROVIDER), Persistenz-Ort
-(bestehende committete `federation_health.json`), Granularität (pro Zyklus, da kein
-Once-per-Run-Hook), Andockstelle (`moksha_health.py`).
+**Geschlossen (DRAFT 0.2/0.3):** Chamber-Erreichbarkeit, Persistenz-Ort, Granularität,
+Andockstelle, Degradations-Messung (Befund 1), Inkrement-Eindeutigkeit (Befund 4),
+None-Guard (Befund 6).
 
-**Bewusst offen — datengesteuert, NICHT vor Beobachtung entscheidbar (Angriffsfläche fürs
-Review):**
-1. Schwelle `N` für „kritisch" — muss aus A-Produktionsdaten kommen, darf nicht geraten
-   werden. Sperrt C.
-2. Prädikat-Verschärfung „alive==0" → „keine erfolgreiche Kognition im Zyklus" (braucht
-   Zyklus-Delta von `total_calls`/`total_failures`) — für C, nicht für A.
-3. Nicht-Atomicity des bestehenden Health-Writes (`write_text`) — vorbestehend; als eigener
-   Hygiene-Punkt zu führen, nicht in dieser Feature.
+**Bewusst offen — datengesteuert:**
+1. **Schwelle `N` — Einheit ist Zyklen** (Befund 5): ein Run addiert bis zu `CYCLES`
+   (Default 4) Zyklen; `N` muss run-sprung-bewusst definiert werden (z. B. „≥N kollabierte
+   Zyklen über ≥M aufeinanderfolgende Runs"), nicht naiv als „N Runs". Aus A-Daten.
+2. Prädikat-Wahl für C (Hard-Down / Degradation / kombiniert) — aus A-Daten.
+3. Atomicity des Health-Writes — **jetzt als C-Blocker (iii) §8 verdrahtet** (Befund 2), nicht
+   mehr nur „separate Hygiene".
 
 ## 11. Schlussstatus
 
-DRAFT 0.2. Schnitt A ausführbar; B/C korrekt gegated. Kein G1, keine Implementierung, keine
-Aktivierung ohne adversariales Review von §5/§8/§10 und Operator-Go.
+DRAFT 0.3. Schnitt A ausführbar und misst das reale Krankheitsbild; B/C korrekt gegated.
+Kein G1, keine Implementierung, keine Aktivierung ohne erneutes Review von §5/§6/§8 und
+Operator-Go.
+
+## 12. Review-Historie
+
+- **Adversariales Design-Review (2026-07-17):** 6 Befunde. Fakten-Fundament unabhängig
+  bestätigt (Anker, `stats()`-Form, `SVC_PROVIDER`, git-tracked Persistenz). Design-Befunde:
+  1 (HIGH, A maß nur Hard-Down statt Degradation) → §5 neu; 2 (HIGH, Non-Atomicity als
+  C-Blocker) → §8(iii)/§10.3; 3 (HIGH, Roundtrip ungetestet) → §6 Roundtrip-Tests; 4 (MED,
+  Doppel-Inkrement) → §5.2 nur Extraktion, §5.3 einzige Inkrement-Stelle; 5 (MED, Einheiten)
+  → §10.1; 6 (LOW, §5.1 vs §5.3 normativ) → §5.1 als illustrativ markiert. G1 blieb korrekt
+  verwehrt.

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
@@ -2,8 +2,9 @@
 
 ## Sichtbarmachung anhaltenden kognitiven/Provider-Kollaps
 
-> **Status:** DRAFT 0.3 — SCHNITT A AUSFÜHRBAR; ADVERSARIAL-REVIEW-BEFUNDE 1–6 EINGEARBEITET;
-> NICHT G1; IMPLEMENTIERUNG UND AKTIVIERUNG GESPERRT
+> **Status:** DRAFT 0.4 — SCHNITT A AUSFÜHRBAR; ZWEI ADVERSARIAL-REVIEW-RUNDEN EINGEARBEITET
+> (inkl. Korrektur des invertierten `degraded`-Prädikats); NICHT G1; IMPLEMENTIERUNG UND
+> AKTIVIERUNG GESPERRT
 > **Datum:** 2026-07-17
 > **Produktionsbasis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
 > **Herkunft:** Phase-2 §7.3; Recon RECON_01–04; adversariales Review (§12)
@@ -29,6 +30,12 @@ Produktionsbasis oben und sind vor Implementierung erneut zu pinnen.
   "total_calls":int, "total_failures":int, …}`. `total_calls`/`total_failures` sind
   prozess-monoton (nur bei frischem Prozess auf 0; `_maybe_reset_daily` `chamber.py:522`
   setzt sie **nicht** zurück).
+- **Zählsemantik (gepinnt — jedes Delta-Prädikat hängt daran):** `_total_calls += 1` steht
+  **ausschließlich** in `_record_call_success` (`chamber.py:471`) ⇒ `total_calls` = Anzahl
+  **gelungener** Invokes, NICHT Versuche. `_total_failures += 1` steht in
+  `_record_call_failure` (`chamber.py:495`) und feuert **pro totem Provider** ⇒ ein einzelner
+  `invoke()` kann `total_failures` um mehrere erhöhen. Ein toter Provider vor einem guten =
+  gesunder Fallback erzeugt Erfolg **und** Failures.
 - Chamber ist Service: `SVC_PROVIDER` `services.py:40`; Registrierung `services.py:285`;
   Get-Muster `context_bridge.py:271`.
 - Health-Builder `_build_health_report()` `moksha_health.py:62`; Writer `moksha_health.py:
@@ -61,8 +68,10 @@ Pro MOKSHA-Zyklus aus `stats()`: `providers_alive`, `providers_total`, `total_ca
 `total_failures`. Abgeleitet über den Zyklus-Delta zum vorigen Report: `calls_delta`,
 `fail_delta`. Zwei Zustände:
 - `hard_down` = `providers_total>0 and providers_alive==0` (Total-Ausfall, Momentwert).
-- `degraded` = `calls_delta>0 and fail_delta>=calls_delta` (im Zyklus wurde Kognition
-  versucht, **keine** gelang) — dies ist das Krankheitsbild aus RECON_01 §4.
+- `degraded` = `calls_delta==0 and fail_delta>0` (Failures traten auf, **kein** Erfolg im
+  Zyklus — weil `total_calls` laut §3 nur Erfolge zählt) — das Krankheitsbild aus RECON_01
+  §4. **Gesunder Fallback (`calls_delta>0`) bleibt bewusst grün**, egal wie viele Failures
+  ein toter Vorgänger-Provider erzeugt.
 
 `collapsed = hard_down or degraded` treibt **einen** Streak.
 
@@ -98,7 +107,7 @@ if provider is not None and hasattr(provider, "stats"):
     else:
         cd = tc; fd = tf
     hard_down = (total > 0 and alive == 0)
-    degraded  = (cd > 0 and fd >= cd)
+    degraded  = (cd == 0 and fd > 0)   # Failures, aber kein Erfolg im Zyklus (§3-Semantik)
     collapsed = hard_down or degraded
     cog.update({"providers_alive": alive, "providers_total": total,
                 "total_calls": tc, "total_failures": tf,
@@ -124,10 +133,14 @@ Builder-Ebene:
   `hard_down False`, `degraded False`, `consecutive_collapsed_cycles==0`.
 - `test_hard_down_increments`: alle Cells nicht-alive, `prev.streak=3` → `hard_down True`,
   `consecutive_collapsed_cycles==4`.
-- `test_degraded_increments` (**Befund 1**): Cells alive, aber `prev.total_calls`/
-  `total_failures` so gesetzt, dass `calls_delta>0 and fail_delta==calls_delta` → `degraded
-  True`, Streak +1 — obwohl `hard_down False`.
-- `test_transient_resets` (**Guard §220.3**): ≥1 Erfolg im Zyklus (`fail_delta<calls_delta`)
+- `test_degraded_increments` (**Befund 1**): Cells alive, Totals so gesetzt, dass
+  `calls_delta==0 and fail_delta>0` (Failures ohne Erfolg im Zyklus) → `degraded True`,
+  Streak +1 — obwohl `hard_down False`.
+- `test_healthy_fallback_stays_green` (**Befund 1b — False-Positive-Guard, Runde 2**):
+  gesunder Fallback, `calls_delta>0 and fail_delta>0` (toter Vorgänger-Provider) →
+  `degraded False`, `consecutive_collapsed_cycles==0` trotz `prev.streak=5`. Fängt die
+  invertierte Prädikat-Version ab.
+- `test_transient_resets` (**Guard §220.3**): ≥1 Erfolg im Zyklus (`calls_delta>0`)
   → `collapsed False`, `consecutive_collapsed_cycles==0` trotz `prev.streak=5`.
 - `test_no_provider_registered`: SVC_PROVIDER fehlt → Block mit `providers_total==0`,
   Streak == `prev.streak`; kein Fehler.
@@ -192,3 +205,11 @@ Operator-Go.
   Doppel-Inkrement) → §5.2 nur Extraktion, §5.3 einzige Inkrement-Stelle; 5 (MED, Einheiten)
   → §10.1; 6 (LOW, §5.1 vs §5.3 normativ) → §5.1 als illustrativ markiert. G1 blieb korrekt
   verwehrt.
+- **Zweite Runde (2026-07-17, Review von DRAFT 0.3):** 1 neuer HIGH-Befund — der Fix für
+  Befund 1 hatte ein **invertiertes** `degraded`-Prädikat eingebaut. Am Code verifiziert:
+  `total_calls` zählt nur Erfolge (`chamber.py:471`), `total_failures` pro totem Provider
+  (`chamber.py:495`). Das alte `cd>0 and fd>=cd` hätte auf gesundem Fallback
+  (Groq-tot→Gemini-ok: `cd=1,fd=1` je Zyklus) **Dauerfehlalarm** erzeugt und das reale
+  Krankheitsbild (`cd==0`) verfehlt. Fix: §3 pinnt jetzt die Zählsemantik; §5 Prädikat
+  korrigiert auf `cd==0 and fd>0`; §6 neuer `test_healthy_fallback_stays_green`. Die 5
+  handwerklich sauberen Befunde (2,3,4,5,6) wurden bestätigt. G1 weiterhin verwehrt.

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
@@ -2,8 +2,8 @@
 
 ## Sichtbarmachung anhaltenden kognitiven/Provider-Kollaps
 
-> **Status:** DRAFT 0.4 — SCHNITT A AUSFÜHRBAR; ZWEI ADVERSARIAL-REVIEW-RUNDEN EINGEARBEITET
-> (inkl. Korrektur des invertierten `degraded`-Prädikats); NICHT G1; IMPLEMENTIERUNG UND
+> **Status:** DRAFT 0.5 — SCHNITT A AUSFÜHRBAR; DREI ADVERSARIAL-REVIEW-RUNDEN EINGEARBEITET
+> (invertiertes Prädikat + Skip-Kollaps-Blindfleck); NICHT G1; IMPLEMENTIERUNG UND
 > AKTIVIERUNG GESPERRT
 > **Datum:** 2026-07-17
 > **Produktionsbasis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
@@ -73,7 +73,19 @@ Pro MOKSHA-Zyklus aus `stats()`: `providers_alive`, `providers_total`, `total_ca
   §4. **Gesunder Fallback (`calls_delta>0`) bleibt bewusst grün**, egal wie viele Failures
   ein toter Vorgänger-Provider erzeugt.
 
-`collapsed = hard_down or degraded` treibt **einen** Streak.
+- `skip_collapse` = `providers_usable==0` (alle Provider **übersprungen** statt versucht:
+  Quota erschöpft `chamber.py:244`, Breaker OPEN `:251`, Membran zu schwach `:255` — jeweils
+  `continue` **ohne** `_record_call_failure`, also `fd=0`). `providers_usable` = pro Provider
+  `alive AND breaker≠OPEN AND within_quota`, ableitbar aus `stats()` (Felder `alive`,
+  `breaker`, chamber-`quota`). Fängt das schwerste Krankheitsbild — Quota-Erschöpfung über
+  einen Tag (RECON_04) und den vertieften Breaker-Steady-State —, das `degraded` (braucht
+  `fd>0`) systematisch verfehlt.
+
+**Partial-Failure bleibt bewusst grün:** ein Zyklus mit ≥1 gelungenem Invoke (`cd>0`) gilt
+als gesund, egal wie viele Failures ein toter Vorgänger-Provider erzeugt. Das ist die
+Auflösungsgrenze, die der C-Prädikat-Designer kennen muss.
+
+`collapsed = hard_down or degraded or skip_collapse` treibt **einen** Streak.
 
 ### 5.2 Lesen-vor-Überschreiben (**nur Extraktion**, kein Rechnen — Befund 4)
 ```
@@ -93,8 +105,9 @@ except (OSError, ValueError, TypeError):
 `return report`:
 ```
 prev = prev or {"consecutive_collapsed_cycles": 0, "total_calls": 0, "total_failures": 0}
-cog = {"providers_alive": 0, "providers_total": 0, "total_calls": 0, "total_failures": 0,
-       "calls_delta": 0, "fail_delta": 0, "hard_down": False, "degraded": False,
+cog = {"providers_alive": 0, "providers_total": 0, "providers_usable": 0,
+       "total_calls": 0, "total_failures": 0, "calls_delta": 0, "fail_delta": 0,
+       "hard_down": False, "degraded": False, "skip_collapse": False,
        "consecutive_collapsed_cycles": prev["consecutive_collapsed_cycles"]}
 provider = ServiceRegistry.get(SVC_PROVIDER)
 if provider is not None and hasattr(provider, "stats"):
@@ -108,11 +121,18 @@ if provider is not None and hasattr(provider, "stats"):
         cd = tc; fd = tf
     hard_down = (total > 0 and alive == 0)
     degraded  = (cd == 0 and fd > 0)   # Failures, aber kein Erfolg im Zyklus (§3-Semantik)
-    collapsed = hard_down or degraded
+    # providers_usable: alive UND breaker≠OPEN UND within_quota. Die exakte Dekodierung von
+    # p['breaker'] und ps['quota'] ist an vibe_core get_status() zu PINNEN (§10.4) — NICHT raten.
+    usable = sum(1 for p in providers
+                 if p.get("alive") and _breaker_ok(p.get("breaker")) and _quota_ok(ps.get("quota")))
+    skip_collapse = (total > 0 and usable == 0)
+    collapsed = hard_down or degraded or skip_collapse
     cog.update({"providers_alive": alive, "providers_total": total,
+                "providers_usable": usable,
                 "total_calls": tc, "total_failures": tf,
                 "calls_delta": cd, "fail_delta": fd,
                 "hard_down": hard_down, "degraded": degraded,
+                "skip_collapse": skip_collapse,
                 "consecutive_collapsed_cycles":
                     prev["consecutive_collapsed_cycles"] + 1 if collapsed else 0})
 report["cognition"] = cog
@@ -144,6 +164,10 @@ Builder-Ebene:
   → `collapsed False`, `consecutive_collapsed_cycles==0` trotz `prev.streak=5`.
 - `test_no_provider_registered`: SVC_PROVIDER fehlt → Block mit `providers_total==0`,
   Streak == `prev.streak`; kein Fehler.
+- `test_skip_collapse_quota` (**Runde 3**): alle Provider im Skip-Zustand (über Quota bzw.
+  Breaker OPEN, via passend geformtem `breaker`/`quota`-Status), `cd==0, fd==0`, aber
+  `providers_usable==0` → `skip_collapse True`, Streak +1. Fängt den Quota-/Breaker-
+  Blindfleck, den `degraded` allein verfehlt.
 
 Disk-Roundtrip-Ebene (**das eigentliche Novum — Befund 3**):
 - `test_roundtrip_increment`: Datei mit `cognition.consecutive_collapsed_cycles=N` +
@@ -189,12 +213,18 @@ None-Guard (Befund 6).
 2. Prädikat-Wahl für C (Hard-Down / Degradation / kombiniert) — aus A-Daten.
 3. Atomicity des Health-Writes — **jetzt als C-Blocker (iii) §8 verdrahtet** (Befund 2), nicht
    mehr nur „separate Hygiene".
+4. **vibe_core-Statusformen pinnen (Runde 3):** die exakte Dekodierung von `p['breaker']`
+   (get_status → wann OPEN), `ps['quota']` (wann erschöpft) und `MahaCellUnified.is_alive`
+   liegt in `vibe_core` (hier nicht installiert). `providers_usable`/`skip_collapse` und der
+   `hard_down`-Backstop hängen daran — vor Implementierung gegen die echten Formen pinnen,
+   **nicht raten** (das war die Fehlerklasse der Runden 2/3). Die Helfer `_breaker_ok`/
+   `_quota_ok` in §5.3 sind Platzhalter für genau diese Dekodierung.
 
 ## 11. Schlussstatus
 
-DRAFT 0.3. Schnitt A ausführbar und misst das reale Krankheitsbild; B/C korrekt gegated.
-Kein G1, keine Implementierung, keine Aktivierung ohne erneutes Review von §5/§6/§8 und
-Operator-Go.
+DRAFT 0.5. Schnitt A misst Hard-Down, Degradation UND Skip-Kollaps; B/C korrekt gegated.
+Einzige tragende ungeprüfte Annahme: die vibe_core-Statusformen (§10.4). Kein G1, keine
+Implementierung, keine Aktivierung ohne erneutes Review von §5/§6/§8 und Operator-Go.
 
 ## 12. Review-Historie
 
@@ -213,3 +243,12 @@ Operator-Go.
   Krankheitsbild (`cd==0`) verfehlt. Fix: §3 pinnt jetzt die Zählsemantik; §5 Prädikat
   korrigiert auf `cd==0 and fd>0`; §6 neuer `test_healthy_fallback_stays_green`. Die 5
   handwerklich sauberen Befunde (2,3,4,5,6) wurden bestätigt. G1 weiterhin verwehrt.
+- **Dritte Runde (2026-07-17, Review von DRAFT 0.4):** 1 neuer HIGH-Befund — `degraded`
+  (`cd==0 and fd>0`) ist blind für **Skip-Kollaps**: die `continue`-Pfade Quota
+  (`chamber.py:244`), Breaker OPEN (`:251`), Membran (`:255`) überspringen Provider **ohne**
+  `_record_call_failure` → `fd=0`. Universeller Skip (v. a. Quota-Erschöpfung über einen Tag,
+  das RECON_04-Krankheitsbild) las sich gesund; `hard_down` fängt es nicht, weil Breaker/Quota
+  `is_alive` nicht anfassen. Am Code verifiziert (Skip-Pfade, Breaker/Lifecycle-Trennung).
+  Fix: neuer Zustand `skip_collapse = providers_usable==0` (§5); Test `test_skip_collapse_quota`
+  (§6); vibe_core-Statusformen als Pin-Pflicht §10.4. `is_alive` bleibt die einzige
+  ungeprüfte tragende Annahme (vibe_core nicht installiert). G1 weiterhin verwehrt.

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
@@ -2,10 +2,11 @@
 
 ## Sichtbarmachung anhaltenden kognitiven/Provider-Kollaps
 
-> **Status:** DRAFT 0.7 — FÜNF ADVERSARIAL-REVIEW-RUNDEN. 4b (Per-Provider-Quota) als TOTER
-> PFAD aufgelöst; einzige verbleibende tragende Lücke ist §10.4a (vibe_core-Statusdekodierung).
-> NICHT G1 / nicht Haiku-implementierbar, bis 4a in einer vibe_core-Umgebung gepinnt ist.
-> IMPL./AKTIVIERUNG GESPERRT
+> **Status:** DRAFT 0.8 — SECHS RUNDEN. §5.3 ist jetzt VOLLSTÄNDIG DEFINIERT (Dekodierung
+> §5.3a gegen echtes `steward-protocol` gepinnt) und damit Haiku-implementierbar. Verbleibend
+> vor G1: (i) Versions-Gegenprüfung der Statusformen gegen die Produktions-`steward-protocol`-
+> Version, (ii) normales Deployment-Gate (Produktionsbeweis, Review, Operator-Go).
+> IMPL./AKTIVIERUNG WEITERHIN GESPERRT bis Operator-Go.
 > **Datum:** 2026-07-17
 > **Produktionsbasis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
 > **Herkunft:** Phase-2 §7.3; Recon RECON_01–04; adversariales Review (§12)
@@ -124,8 +125,7 @@ if provider is not None and hasattr(provider, "stats"):
         cd = tc; fd = tf
     hard_down = (total > 0 and alive == 0)
     degraded  = (cd == 0 and fd > 0)   # Failures, aber kein Erfolg im Zyklus (§3-Semantik)
-    # providers_usable: alive UND breaker≠OPEN UND within_quota. Die exakte Dekodierung von
-    # p['breaker'] und ps['quota'] ist an vibe_core get_status() zu PINNEN (§10.4) — NICHT raten.
+    # providers_usable: alive UND breaker≠OPEN UND within_quota. Dekodierung §5.3a (gepinnt).
     usable = sum(1 for p in providers
                  if p.get("alive") and _breaker_ok(p.get("breaker")) and _quota_ok(ps.get("quota")))
     skip_collapse = (total > 0 and usable == 0)
@@ -140,6 +140,33 @@ if provider is not None and hasattr(provider, "stats"):
                     prev["consecutive_collapsed_cycles"] + 1 if collapsed else 0})
 report["cognition"] = cog
 ```
+
+### 5.3a Statusdekodierung — GEPINNT gegen `steward-protocol` (vibe_core), verifiziert
+`p["breaker"]` ist `CircuitBreaker.get_status()` (dict oder `None`), `ps["quota"]` ist
+`OperationalQuota.get_status()`. Am echten Code gelesen (`steward-protocol==0.3.2`):
+```
+def _breaker_ok(b: dict | None) -> bool:
+    # CircuitBreakerState = {closed, open, half_open}; can_execute()==False nur bei OPEN.
+    return b is None or b.get("state") != "open"
+
+def _quota_ok(q: dict | None) -> bool:
+    # check_before_request raist bei RPM/TPM/Cost. Konservative Snapshot-Näherung aus get_status():
+    if not q:
+        return True
+    r = q.get("requests", {}); t = q.get("tokens", {}); c = q.get("cost", {})
+    return (r.get("percent_used", 0) < 100 and t.get("percent_used", 0) < 100
+            and c.get("this_hour_usd", 0) < c.get("limit_per_hour_usd", float("inf")))
+```
+**`is_alive`** ist `lifecycle.is_active and lifecycle.prana > 0`; `stats()` liefert genau das
+schon als Feld `alive` — `hard_down`/`usable` nutzen es direkt, keine Neuberechnung.
+
+**Ehrliche Restgrenze (kein Rateanteil, aber benannt):** `_breaker_ok`/`_quota_ok` lesen den
+`get_status()`-**Snapshot** zum MOKSHA-Zeitpunkt; die echten Skips nutzen zusätzlich
+Live-Größen (Breaker-Recovery-Timeout, geschätzte Tokens/Kosten der *nächsten* Anfrage). Für
+ein **Instrument** ist die Snapshot-Näherung bewusst konservativ (OPEN/„≥100 %" = nicht
+nutzbar). Und: gepinnt gegen `0.3.2` (PyPI) — Produktion installiert `steward-protocol`
+editable aus `main` (`steward-heartbeat.yml:49`); **vor G1 die Statusformen gegen die exakte
+Produktionsversion gegenprüfen** (oder die Version pinnen).
 
 ### 5.4 Invariante
 Schnitt A ändert **keinen** Kontrollfluss außerhalb `moksha_health.py`, wirft nicht (der
@@ -217,12 +244,15 @@ None-Guard (Befund 6).
 2. Prädikat-Wahl für C (Hard-Down / Degradation / kombiniert) — aus A-Daten.
 3. Atomicity des Health-Writes — **jetzt als C-Blocker (iii) §8 verdrahtet** (Befund 2), nicht
    mehr nur „separate Hygiene".
-4. **NORMATIVE KERN-LÜCKE — §5.3 ist bis hierhin NICHT ausführbar.** Zwei getrennte Teile:
+4. **Statusdekodierung §5.3 — AUFGELÖST (Runde 6).**
 
-   **4a — Dekodierung (Runde 3):** `_breaker_ok(p['breaker'])`, `is_alive` und der globale
-   `ps['quota']`-Status liegen in `vibe_core` (hier nicht installiert). Exakte Formen (wann
-   „OPEN", wann „erschöpft") vor Implementierung gegen den echten `get_status()` pinnen,
-   **nicht raten**. `_breaker_ok`/`_quota_ok` in §5.3 sind Platzhalter dafür.
+   **4a — GEPINNT.** `steward-protocol` (das Distributions-Paket hinter dem Import
+   `vibe_core`, `pyproject.toml` `dependencies`) wurde installiert und die echten Formen
+   gelesen: `CircuitBreakerState = {closed,open,half_open}` (Skip nur bei `open`),
+   `OperationalQuota.get_status()` (RPM/TPM/Cost-Struktur), `is_alive = is_active and prana>0`
+   (in `stats()` als `alive`). `_breaker_ok`/`_quota_ok` sind in §5.3a **definiert**, keine
+   Platzhalter mehr. Einzige benannte Restgrenze: Snapshot-Näherung + Versions-Gegenprüfung
+   gegen die Produktions-`steward-protocol`-Version (§5.3a).
 
    **4b — AUFGELÖST (Runde 5): der Per-Provider-Quota-Skip `:244` ist ein TOTER PFAD.**
    Runde 4 rahmte dies als Datenlücke + Operator-Entscheidung. Am Code widerlegt: der Skip
@@ -249,11 +279,11 @@ None-Guard (Befund 6).
 
 ## 11. Schlussstatus
 
-DRAFT 0.7. Schnitt A misst Hard-Down, Degradation und Skip-Kollaps; B/C korrekt gegated.
-**Einziger verbleibender G1-Blocker: §10.4a** — die vibe_core-Statusdekodierung
-(`_breaker_ok`/`_quota_ok`/`is_alive`), zu pinnen in einer Umgebung *mit* `vibe_core`; dieses
-Environment kann es nicht. Danach ist G1 plausibel. Kein G1/Impl./Aktivierung ohne 4a +
-erneutes Review + Operator-Go.
+DRAFT 0.8. Schnitt A misst Hard-Down, Degradation und Skip-Kollaps; §5.3 vollständig
+definiert (Dekodierung §5.3a gegen echtes `steward-protocol` gepinnt). B/C korrekt gegated.
+**Verbleibend vor G1:** (i) Statusformen gegen die Produktions-`steward-protocol`-Version
+gegenprüfen (§5.3a); (ii) normales Deployment-Gate. Kein Impl./Aktivierung ohne Review +
+Operator-Go.
 
 **Minor (für den C-Designer):** `skip_collapse` ist ein **Kapazitäts**-Prädikat („könnten
 wir kognizieren?"), in denselben Streak gefaltet wie die **Failure**-Prädikate
@@ -306,3 +336,12 @@ Inkrement heißt also nicht immer „Kognition scheiterte".
   normativ (Reviewer hier am Code widerlegt). Folgen: §10.4b neu (toter Pfad + Latent-Guard),
   §5.1 präzisiert, `test_skip_collapse_quota` → `test_skip_collapse_breaker` (lebender Pfad).
   Einziger G1-Blocker bleibt §10.4a (vibe_core-Dekodierung). G1 verwehrt.
+- **Sechste Runde (2026-07-17, Operator-Einwand „das ist doch ein PyPI-Package"):** berechtigt
+  — der Lead-Agent hatte §10.4a fälschlich als unlösbares Umgebungsproblem gerahmt, ohne
+  `pyproject.toml.dependencies` zu lesen. `vibe_core` wird vom PyPI-Paket **`steward-protocol`**
+  geliefert (Import-Name ≠ Distributionsname). `pip install steward-protocol` (0.3.2), echte
+  Formen gelesen und §5.3a **gepinnt**: `_breaker_ok`=`state!="open"`, `_quota_ok`=Snapshot-
+  Näherung aus `get_status()`, `is_alive`=`is_active and prana>0` (= `stats()`-Feld `alive`).
+  §10.4a von OFFEN → AUFGELÖST. §5.3 ist jetzt vollständig definiert. Restgrenze:
+  Snapshot-Näherung + Versions-Gegenprüfung gegen Produktion. Methoden-Lehre: „geht hier
+  nicht" erst behaupten, wenn Beschaffung (pip/dep-graph) geprüft ist — nicht davor.

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md
@@ -2,11 +2,13 @@
 
 ## Sichtbarmachung anhaltenden kognitiven/Provider-Kollaps
 
-> **Status:** DRAFT 0.8 — SECHS RUNDEN. §5.3 ist jetzt VOLLSTÄNDIG DEFINIERT (Dekodierung
-> §5.3a gegen echtes `steward-protocol` gepinnt) und damit Haiku-implementierbar. Verbleibend
-> vor G1: (i) Versions-Gegenprüfung der Statusformen gegen die Produktions-`steward-protocol`-
-> Version, (ii) normales Deployment-Gate (Produktionsbeweis, Review, Operator-Go).
-> IMPL./AKTIVIERUNG WEITERHIN GESPERRT bis Operator-Go.
+> **Status:** DRAFT 1.0 — SIEBEN REVIEW-RUNDEN, BEDINGTES GO. §5.3 vollständig definiert und
+> **fail-laut** (Dekoder werfen bei Form-Drift statt still „gesund" zu lesen, Befund 1);
+> Prosa/Code-Konsistenz hergestellt (Membran-Skip bewusst nicht erfasst, Befund 2);
+> Snapshot-Verzerrung benannt (Befund 3). Keine Designfehler mehr offen. **G1 formal erst
+> nach:** (i) Versions-Gegenprüfung der Statusformen gegen die Produktions-`steward-protocol`-
+> Version als **Impl-Schritt 1**; (ii) normales Deployment-Gate + Operator-Go. IMPL./
+> AKTIVIERUNG GESPERRT bis Operator-Go.
 > **Datum:** 2026-07-17
 > **Produktionsbasis:** `kimeisele/steward@bf2fba2075a87463fc8e333f8f57d805fce4d030`
 > **Herkunft:** Phase-2 §7.3; Recon RECON_01–04; adversariales Review (§12)
@@ -111,7 +113,7 @@ except (OSError, ValueError, TypeError):
 prev = prev or {"consecutive_collapsed_cycles": 0, "total_calls": 0, "total_failures": 0}
 cog = {"providers_alive": 0, "providers_total": 0, "providers_usable": 0,
        "total_calls": 0, "total_failures": 0, "calls_delta": 0, "fail_delta": 0,
-       "hard_down": False, "degraded": False, "skip_collapse": False,
+       "hard_down": False, "degraded": False, "skip_collapse": False, "decode_error": None,
        "consecutive_collapsed_cycles": prev["consecutive_collapsed_cycles"]}
 provider = ServiceRegistry.get(SVC_PROVIDER)
 if provider is not None and hasattr(provider, "stats"):
@@ -126,18 +128,24 @@ if provider is not None and hasattr(provider, "stats"):
     hard_down = (total > 0 and alive == 0)
     degraded  = (cd == 0 and fd > 0)   # Failures, aber kein Erfolg im Zyklus (§3-Semantik)
     # providers_usable: alive UND breaker≠OPEN UND within_quota. Dekodierung §5.3a (gepinnt).
-    usable = sum(1 for p in providers
-                 if p.get("alive") and _breaker_ok(p.get("breaker")) and _quota_ok(ps.get("quota")))
-    skip_collapse = (total > 0 and usable == 0)
-    collapsed = hard_down or degraded or skip_collapse
+    try:
+        usable = sum(1 for p in providers
+                     if p.get("alive") and _breaker_ok(p.get("breaker")) and _quota_ok(ps.get("quota")))
+        skip_collapse = (total > 0 and usable == 0)
+        collapsed = hard_down or degraded or skip_collapse
+        streak = prev["consecutive_collapsed_cycles"] + 1 if collapsed else 0
+    except _ShapeDrift as e:                       # Befund 1: fail-laut, nicht still „gesund"
+        logger.warning("cognition decode drift: %s", e)
+        usable = 0; skip_collapse = False
+        cog["decode_error"] = str(e)
+        streak = prev["consecutive_collapsed_cycles"]   # Streak eingefroren, nicht geraten
     cog.update({"providers_alive": alive, "providers_total": total,
                 "providers_usable": usable,
                 "total_calls": tc, "total_failures": tf,
                 "calls_delta": cd, "fail_delta": fd,
                 "hard_down": hard_down, "degraded": degraded,
                 "skip_collapse": skip_collapse,
-                "consecutive_collapsed_cycles":
-                    prev["consecutive_collapsed_cycles"] + 1 if collapsed else 0})
+                "consecutive_collapsed_cycles": streak})
 report["cognition"] = cog
 ```
 
@@ -145,28 +153,47 @@ report["cognition"] = cog
 `p["breaker"]` ist `CircuitBreaker.get_status()` (dict oder `None`), `ps["quota"]` ist
 `OperationalQuota.get_status()`. Am echten Code gelesen (`steward-protocol==0.3.2`):
 ```
+class _ShapeDrift(Exception):   # steward-protocol get_status()-Form weicht ab
+    pass
+
 def _breaker_ok(b: dict | None) -> bool:
-    # CircuitBreakerState = {closed, open, half_open}; can_execute()==False nur bei OPEN.
-    return b is None or b.get("state") != "open"
+    if b is None:
+        return True                       # kein Breaker für diesen Provider = nutzbar
+    if "state" not in b:                  # FAIL-LAUT statt still „gesund" (Befund 1)
+        raise _ShapeDrift("breaker.get_status(): 'state' fehlt")
+    return b["state"] != "open"           # {closed, open, half_open}; Skip nur bei OPEN
 
 def _quota_ok(q: dict | None) -> bool:
-    # check_before_request raist bei RPM/TPM/Cost. Konservative Snapshot-Näherung aus get_status():
     if not q:
         return True
-    r = q.get("requests", {}); t = q.get("tokens", {}); c = q.get("cost", {})
-    return (r.get("percent_used", 0) < 100 and t.get("percent_used", 0) < 100
-            and c.get("this_hour_usd", 0) < c.get("limit_per_hour_usd", float("inf")))
+    try:                                  # fehlende erwartete Keys → FAIL-LAUT (Befund 1)
+        return (q["requests"]["percent_used"] < 100
+                and q["tokens"]["percent_used"] < 100
+                and q["cost"]["this_hour_usd"] < q["cost"]["limit_per_hour_usd"])
+    except (KeyError, TypeError) as e:
+        raise _ShapeDrift(f"quota.get_status()-Form: {e}")
 ```
 **`is_alive`** ist `lifecycle.is_active and lifecycle.prana > 0`; `stats()` liefert genau das
 schon als Feld `alive` — `hard_down`/`usable` nutzen es direkt, keine Neuberechnung.
 
-**Ehrliche Restgrenze (kein Rateanteil, aber benannt):** `_breaker_ok`/`_quota_ok` lesen den
-`get_status()`-**Snapshot** zum MOKSHA-Zeitpunkt; die echten Skips nutzen zusätzlich
-Live-Größen (Breaker-Recovery-Timeout, geschätzte Tokens/Kosten der *nächsten* Anfrage). Für
-ein **Instrument** ist die Snapshot-Näherung bewusst konservativ (OPEN/„≥100 %" = nicht
-nutzbar). Und: gepinnt gegen `0.3.2` (PyPI) — Produktion installiert `steward-protocol`
-editable aus `main` (`steward-heartbeat.yml:49`); **vor G1 die Statusformen gegen die exakte
-Produktionsversion gegenprüfen** (oder die Version pinnen).
+**Fail-laut im Builder (Befund 1):** die `usable`-Berechnung (§5.3) wird mit
+`try/except _ShapeDrift` umschlossen. Bei Drift: `cog["decode_error"] = <detail>` **setzen**
++ `logger.warning`, `skip_collapse` bleibt `False` und der Streak wird in diesem Zyklus
+**nicht** fortgeschrieben. So liest das Instrument bei unerwarteter Form **nicht still
+„gesund"** — die Drift ist als Feld `decode_error` im Artefakt sichtbar. Zusätzlich validiert
+`execute()` beim ersten Aufruf die Form einmal gegen die installierte Version.
+
+**Versionsabgleich ist IMPLEMENTIERUNGS-SCHRITT 1, nicht danach (Befund 1):** gepinnt gegen
+`steward-protocol==0.3.2` (PyPI); Produktion installiert editable aus `main`
+(`steward-heartbeat.yml:49`). Bevor eine Zeile von §5.3 geschrieben wird, die drei Formen
+(`CircuitBreaker.get_status`, `OperationalQuota.get_status`, `MahaCellUnified.is_alive`) gegen
+die exakte Produktionsversion gegenlesen (oder die Dependency-Version pinnen). Das Fail-laut
+oben macht jede Drift, die *nach* diesem Abgleich entsteht, sichtbar statt blind.
+
+**Snapshot-Näherung (benannt):** `_breaker_ok`/`_quota_ok` lesen den `get_status()`-Snapshot
+zum MOKSHA-Zeitpunkt; die echten Skips nutzen zusätzlich Live-Größen (Recovery-Timeout,
+geschätzte Tokens/Kosten der nächsten Anfrage). Bewusst konservativ (OPEN/„≥100 %" = nicht
+nutzbar). Verzerrungsrichtung siehe §10.1.
 
 ### 5.4 Invariante
 Schnitt A ändert **keinen** Kontrollfluss außerhalb `moksha_health.py`, wirft nicht (der
@@ -199,6 +226,11 @@ Builder-Ebene:
   `providers_usable==0` → `skip_collapse True`, Streak +1. Treibt den **erreichbaren**
   Skip-Pfad (`chamber.py:251`), nicht die tote Per-Provider-Quota-Form (`:244`) — sonst
   „grüner Test, tote Produktion" (§220.3).
+- `test_decode_error_fails_loud` (**Runde 7, Befund 1**): `stats()` liefert einen `breaker`-
+  Dict **ohne** `state`-Key (simulierte Form-Drift) → `_ShapeDrift` → `cog["decode_error"]`
+  ist gesetzt, `logger.warning` gefeuert, `consecutive_collapsed_cycles == prev` (eingefroren,
+  **nicht** auf 0 „gesund" geraten), Run-Exit unverändert. Beweist, dass Drift sichtbar wird
+  statt still gesund.
 
 Disk-Roundtrip-Ebene (**das eigentliche Novum — Befund 3**):
 - `test_roundtrip_increment`: Datei mit `cognition.consecutive_collapsed_cycles=N` +
@@ -241,6 +273,11 @@ None-Guard (Befund 6).
 1. **Schwelle `N` — Einheit ist Zyklen** (Befund 5): ein Run addiert bis zu `CYCLES`
    (Default 4) Zyklen; `N` muss run-sprung-bewusst definiert werden (z. B. „≥N kollabierte
    Zyklen über ≥M aufeinanderfolgende Runs"), nicht naiv als „N Runs". Aus A-Daten.
+   **Verzerrungs-Richtung (Befund 3):** `_breaker_ok` rekonstruiert das dynamische
+   `can_execute()==False` aus einem statischen `state`-Snapshot. An der OPEN→HALF_OPEN-
+   Recovery-Grenze zeigt `state` noch „open", während `can_execute()` schon einen Probe
+   erlaubt ⇒ `skip_collapse` **überzählt** Kollaps-Zyklen während der Erholung. `N` aus
+   A-Daten daher gegen diese Aufwärts-Verzerrung kalibrieren.
 2. Prädikat-Wahl für C (Hard-Down / Degradation / kombiniert) — aus A-Daten.
 3. Atomicity des Health-Writes — **jetzt als C-Blocker (iii) §8 verdrahtet** (Befund 2), nicht
    mehr nur „separate Hygiene".
@@ -269,21 +306,29 @@ None-Guard (Befund 6).
    `skip_collapse` erneut prüfen (Feld in `stats()` exponieren oder Blindfleck bewusst
    tragen).*
 
-   **Lebende `skip_collapse`-Eingänge** sind damit: Breaker-OPEN (`:251`), schwache Membran
-   (`:255`) und **globale** Quota-Erschöpfung (`self._quota.check_before_request` am Kopf von
-   `invoke()`, `chamber.py:231–238`, `return None`). Alle drei sind aus `stats()` (`breaker`,
-   `integrity`/`alive`, globaler `quota`) unter 4a rekonstruierbar — 4b kollabiert in 4a.
-   *Hinweis:* Reviewer-Runde-5-Punkt „`_quota_ok` sei Streaming-only tot" ist am Code
-   widerlegt — der globale Quota-Check steht auch im non-streaming `invoke()` (`:231`), also
-   bleibt `_quota_ok` erreichbar und normativ.
+   **Lebende `skip_collapse`-Eingänge:** Breaker-OPEN (`:251`) und **globale** Quota-
+   Erschöpfung (`self._quota.check_before_request` am Kopf von `invoke()`, `chamber.py:231–238`,
+   `return None`) — **beide** von `usable` erfasst (`_breaker_ok`, `_quota_ok`), aus `stats()`
+   (`breaker`, globaler `quota`) rekonstruierbar. *Hinweis:* Reviewer-Runde-5-Punkt „`_quota_ok`
+   sei Streaming-only tot" ist am Code widerlegt — der globale Check steht auch im
+   non-streaming `invoke()` (`:231`).
+
+   **Membran-Skip (`:255`) wird bewusst NICHT separat erkannt (Befund 2):** `usable` prüft
+   `alive AND breaker AND quota`, **nicht** `integrity`. Eine Zelle kann `alive=True`
+   (`is_active ∧ prana>0`) und trotzdem an `:255` übersprungen werden, weil Failures die
+   *Integrität* senken (`chamber.py:502`), nicht prana. Dieser Pfad wird vom Breaker-Skip
+   (`:251`, niedrigere Schwelle) höchstwahrscheinlich maskiert; und die Membran-Schwelle in
+   `cell.signal` liegt in `vibe_core` und ist **nicht gepinnt**. Daher: bewusster Verzicht,
+   **keine** Behauptung einer `integrity`-Rekonstruktion. Wird der Pfad je relevant, ist die
+   `cell.signal`-Schwelle wie 4a zu pinnen und `usable` zu erweitern.
 
 ## 11. Schlussstatus
 
-DRAFT 0.8. Schnitt A misst Hard-Down, Degradation und Skip-Kollaps; §5.3 vollständig
-definiert (Dekodierung §5.3a gegen echtes `steward-protocol` gepinnt). B/C korrekt gegated.
+DRAFT 1.0 — bedingtes Go. Schnitt A misst Hard-Down, Degradation und Skip-Kollaps; §5.3
+vollständig definiert, fail-laut, ohne offene Designfehler. B/C korrekt gegated.
 **Verbleibend vor G1:** (i) Statusformen gegen die Produktions-`steward-protocol`-Version
-gegenprüfen (§5.3a); (ii) normales Deployment-Gate. Kein Impl./Aktivierung ohne Review +
-Operator-Go.
+gegenprüfen — **als erster Implementierungsschritt** (§5.3a); (ii) normales Deployment-Gate.
+Kein Impl./Aktivierung ohne Review + Operator-Go.
 
 **Minor (für den C-Designer):** `skip_collapse` ist ein **Kapazitäts**-Prädikat („könnten
 wir kognizieren?"), in denselben Streak gefaltet wie die **Failure**-Prädikate
@@ -345,3 +390,13 @@ Inkrement heißt also nicht immer „Kognition scheiterte".
   §10.4a von OFFEN → AUFGELÖST. §5.3 ist jetzt vollständig definiert. Restgrenze:
   Snapshot-Näherung + Versions-Gegenprüfung gegen Produktion. Methoden-Lehre: „geht hier
   nicht" erst behaupten, wenn Beschaffung (pip/dep-graph) geprüft ist — nicht davor.
+- **Siebte Runde (2026-07-17, finales Review von DRAFT 0.8): BEDINGTES GO.** Keine
+  Designfehler mehr — drei kleine Härtungen: (1, MED-HIGH) die §5.3a-Dekoder lasen bei
+  Form-Drift still „gesund" (`.get(key, healthy_default)`) → **fail-laut** umgebaut
+  (`_ShapeDrift` + `decode_error`-Feld + Streak eingefroren), plus Versionsabgleich als
+  Impl-Schritt 1; (2, MED) §10.4 behauptete eine `integrity`/Membran-Rekonstruktion, die
+  `usable` nicht leistet → Behauptung entfernt, Membran-Skip `:255` bewusst als
+  nicht-separat-erfasst dokumentiert; (3, LOW) Snapshot-Verzerrung überzählt Kollaps während
+  Breaker-Recovery → in §10.1 benannt. Der Reviewer korrigierte zudem seinen eigenen
+  Runde-5-Fehler (globaler Quota IST im non-streaming `invoke()` erreichbar). Verbleibend nur
+  noch Versionsabgleich + Deployment-Gate; nächster sinnvoller Schritt ist Code, nicht Review.

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
@@ -93,11 +93,11 @@ machen — LOGGING zuerst, kein erzwungenes Rot vor Beobachtung.
 **Recon abgeschlossen (RECON_01–04).** Die Fehlerklassen-Matrix ist vollständig belegt
 (RECON_04 §5). Kein offener Recon-Punkt ist vor der Spec zwingend.
 
-Feature-Spec liegt als **DRAFT 0.6** vor: `HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`
-(NICHT G1). **Vier** adversariale Review-Runden. Schnitt A misst Hard-Down, Degradation und
-Skip-Kollaps; Non-Atomicity als C-Blocker; Roundtrip getestet. **Zwei benannte, tragende
-Lücken im normativen Kern blockieren G1** (FEATURE-01 §10.4): (4a) vibe_core-Statusformen
-pinnen [braucht vibe_core-Umgebung]; (4b) Per-Provider-Quota-Datenlücke — `stats()` trägt
-`calls_today`/`daily_call_limit` nicht, also ist `skip_collapse` für Free-Tier-Quota blind —
-Operator-Entscheidung (a) `stats()` erweitern [Re-Scope] vs. (b) Blindfleck dokumentieren.
-**Kein G1, kein Produktcode ohne beides + erneutes Review + Operator-Go.**
+Feature-Spec liegt als **DRAFT 0.7** vor: `HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`
+(NICHT G1). **Fünf** adversariale Review-Runden. Schnitt A misst Hard-Down, Degradation und
+Skip-Kollaps; Non-Atomicity als C-Blocker; Roundtrip getestet. Der vermeintliche
+Per-Provider-Quota-Blindfleck (Runde 4) ist als **toter Pfad** aufgelöst (`calls_today` wird
+nie inkrementiert) — keine Operator-Entscheidung mehr nötig. **Einziger verbleibender
+G1-Blocker: §10.4a** — die vibe_core-Statusdekodierung (`breaker`/`quota`/`is_alive`
+`get_status`), zu pinnen in einer Umgebung *mit* `vibe_core`; dieses Environment kann es
+nicht. **Kein G1, kein Produktcode ohne 4a + erneutes Review + Operator-Go.**

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
@@ -93,8 +93,9 @@ machen — LOGGING zuerst, kein erzwungenes Rot vor Beobachtung.
 **Recon abgeschlossen (RECON_01–04).** Die Fehlerklassen-Matrix ist vollständig belegt
 (RECON_04 §5). Kein offener Recon-Punkt ist vor der Spec zwingend.
 
-Feature-Spec liegt als **DRAFT** vor: `HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`
-(Status DRAFT 0.1 — NICHT G1). Zielarchitektur: vorhandene `vedana`/`health_anomaly`-
-Erkennung bei *anhaltendem* Kollaps nach außen sichtbar machen + persistierter Kollaps-
-Zähler über Runs; LOGGING vor Erzwingen; Rollback. Nächster Schritt: adversariales Review
-der DRAFT-Spec (§10 dort). **Kein G1, kein Produktcode ohne ausdrückliches Operator-Go.**
+Feature-Spec liegt als **DRAFT 0.3** vor: `HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`
+(NICHT G1). Ein adversariales Design-Review (6 Befunde) ist eingearbeitet — u.a. misst
+Schnitt A jetzt die reale Degradation (Zyklus-Delta), nicht nur Hard-Down; Non-Atomicity ist
+als C-Blocker verdrahtet; der Disk-Roundtrip ist im Testvertrag abgedeckt (Details
+FEATURE-01 §12). **Kein G1, kein Produktcode ohne erneutes Review und ausdrückliches
+Operator-Go.**

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
@@ -93,12 +93,12 @@ machen — LOGGING zuerst, kein erzwungenes Rot vor Beobachtung.
 **Recon abgeschlossen (RECON_01–04).** Die Fehlerklassen-Matrix ist vollständig belegt
 (RECON_04 §5). Kein offener Recon-Punkt ist vor der Spec zwingend.
 
-Feature-Spec liegt als **DRAFT 0.8** vor: `HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`
-(NICHT G1). **Sechs** Runden. Schnitt A misst Hard-Down, Degradation und Skip-Kollaps;
-Non-Atomicity als C-Blocker; Roundtrip getestet. Per-Provider-Quota (Runde 4) als toter Pfad
-aufgelöst. **§10.4a ist gepinnt und AUFGELÖST:** `vibe_core` kommt vom PyPI-Paket
-`steward-protocol` — installiert, echte `get_status()`-Formen gelesen, `_breaker_ok`/
-`_quota_ok`/`is_alive` in §5.3a definiert. §5.3 ist damit vollständig/Haiku-implementierbar.
-**Verbleibend vor G1:** Versions-Gegenprüfung der Statusformen gegen die Produktions-
-`steward-protocol`-Version + normales Deployment-Gate. **Kein Produktcode ohne Review +
-Operator-Go.**
+Feature-Spec liegt als **DRAFT 1.0 — bedingtes Go** vor:
+`HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`. **Sieben** Review-Runden, keine offenen
+Designfehler. Schnitt A misst Hard-Down, Degradation und Skip-Kollaps; §5.3 vollständig
+definiert und **fail-laut** (Dekoder werfen bei `steward-protocol`-Form-Drift statt still
+„gesund" zu lesen); §10.4a gepinnt (`vibe_core` via PyPI-Paket `steward-protocol`);
+Per-Provider-Quota als toter Pfad aufgelöst; Membran-Skip bewusst nicht erfasst.
+**Verbleibend vor formalem G1:** (i) Statusform-Gegenprüfung gegen die Produktions-
+`steward-protocol`-Version als **erster Implementierungsschritt**; (ii) normales
+Deployment-Gate. **Kein Produktcode ohne Operator-Go.**

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
@@ -93,9 +93,10 @@ machen — LOGGING zuerst, kein erzwungenes Rot vor Beobachtung.
 **Recon abgeschlossen (RECON_01–04).** Die Fehlerklassen-Matrix ist vollständig belegt
 (RECON_04 §5). Kein offener Recon-Punkt ist vor der Spec zwingend.
 
-Feature-Spec liegt als **DRAFT 0.3** vor: `HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`
-(NICHT G1). Ein adversariales Design-Review (6 Befunde) ist eingearbeitet — u.a. misst
-Schnitt A jetzt die reale Degradation (Zyklus-Delta), nicht nur Hard-Down; Non-Atomicity ist
-als C-Blocker verdrahtet; der Disk-Roundtrip ist im Testvertrag abgedeckt (Details
-FEATURE-01 §12). **Kein G1, kein Produktcode ohne erneutes Review und ausdrückliches
-Operator-Go.**
+Feature-Spec liegt als **DRAFT 0.5** vor: `HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`
+(NICHT G1). **Drei** adversariale Review-Runden sind eingearbeitet — Schnitt A misst jetzt
+Hard-Down, Degradation (`cd==0 and fd>0`) **und** Skip-Kollaps (`providers_usable==0`, gegen
+Quota-/Breaker-Erschöpfung); Non-Atomicity als C-Blocker verdrahtet; Roundtrip getestet.
+Einzige ungeprüfte tragende Annahme: die vibe_core-Statusformen (`is_alive`, breaker/quota
+`get_status`), zu pinnen vor Implementierung (FEATURE-01 §10.4/§12). **Kein G1, kein
+Produktcode ohne erneutes Review und ausdrückliches Operator-Go.**

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
@@ -93,11 +93,12 @@ machen — LOGGING zuerst, kein erzwungenes Rot vor Beobachtung.
 **Recon abgeschlossen (RECON_01–04).** Die Fehlerklassen-Matrix ist vollständig belegt
 (RECON_04 §5). Kein offener Recon-Punkt ist vor der Spec zwingend.
 
-Feature-Spec liegt als **DRAFT 0.7** vor: `HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`
-(NICHT G1). **Fünf** adversariale Review-Runden. Schnitt A misst Hard-Down, Degradation und
-Skip-Kollaps; Non-Atomicity als C-Blocker; Roundtrip getestet. Der vermeintliche
-Per-Provider-Quota-Blindfleck (Runde 4) ist als **toter Pfad** aufgelöst (`calls_today` wird
-nie inkrementiert) — keine Operator-Entscheidung mehr nötig. **Einziger verbleibender
-G1-Blocker: §10.4a** — die vibe_core-Statusdekodierung (`breaker`/`quota`/`is_alive`
-`get_status`), zu pinnen in einer Umgebung *mit* `vibe_core`; dieses Environment kann es
-nicht. **Kein G1, kein Produktcode ohne 4a + erneutes Review + Operator-Go.**
+Feature-Spec liegt als **DRAFT 0.8** vor: `HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`
+(NICHT G1). **Sechs** Runden. Schnitt A misst Hard-Down, Degradation und Skip-Kollaps;
+Non-Atomicity als C-Blocker; Roundtrip getestet. Per-Provider-Quota (Runde 4) als toter Pfad
+aufgelöst. **§10.4a ist gepinnt und AUFGELÖST:** `vibe_core` kommt vom PyPI-Paket
+`steward-protocol` — installiert, echte `get_status()`-Formen gelesen, `_breaker_ok`/
+`_quota_ok`/`is_alive` in §5.3a definiert. §5.3 ist damit vollständig/Haiku-implementierbar.
+**Verbleibend vor G1:** Versions-Gegenprüfung der Statusformen gegen die Produktions-
+`steward-protocol`-Version + normales Deployment-Gate. **Kein Produktcode ohne Review +
+Operator-Go.**

--- a/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
+++ b/specs/HEARTBEAT_FAILURE_PROPAGATION_SYSTEM_SPEC.md
@@ -93,10 +93,11 @@ machen — LOGGING zuerst, kein erzwungenes Rot vor Beobachtung.
 **Recon abgeschlossen (RECON_01–04).** Die Fehlerklassen-Matrix ist vollständig belegt
 (RECON_04 §5). Kein offener Recon-Punkt ist vor der Spec zwingend.
 
-Feature-Spec liegt als **DRAFT 0.5** vor: `HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`
-(NICHT G1). **Drei** adversariale Review-Runden sind eingearbeitet — Schnitt A misst jetzt
-Hard-Down, Degradation (`cd==0 and fd>0`) **und** Skip-Kollaps (`providers_usable==0`, gegen
-Quota-/Breaker-Erschöpfung); Non-Atomicity als C-Blocker verdrahtet; Roundtrip getestet.
-Einzige ungeprüfte tragende Annahme: die vibe_core-Statusformen (`is_alive`, breaker/quota
-`get_status`), zu pinnen vor Implementierung (FEATURE-01 §10.4/§12). **Kein G1, kein
-Produktcode ohne erneutes Review und ausdrückliches Operator-Go.**
+Feature-Spec liegt als **DRAFT 0.6** vor: `HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`
+(NICHT G1). **Vier** adversariale Review-Runden. Schnitt A misst Hard-Down, Degradation und
+Skip-Kollaps; Non-Atomicity als C-Blocker; Roundtrip getestet. **Zwei benannte, tragende
+Lücken im normativen Kern blockieren G1** (FEATURE-01 §10.4): (4a) vibe_core-Statusformen
+pinnen [braucht vibe_core-Umgebung]; (4b) Per-Provider-Quota-Datenlücke — `stats()` trägt
+`calls_today`/`daily_call_limit` nicht, also ist `skip_collapse` für Free-Tier-Quota blind —
+Operator-Entscheidung (a) `stats()` erweitern [Re-Scope] vs. (b) Blindfleck dokumentieren.
+**Kein G1, kein Produktcode ohne beides + erneutes Review + Operator-Go.**


### PR DESCRIPTION
Follow-up to the merged #681. Rebuilt on current `main` (after #681 + #682 + heartbeat state) so it touches **only** the two heartbeat-failure-propagation spec files — no rollback of the context-bridge D2a work or federation state.

## What changed

Incorporates the adversarial design review's six findings into the feature spec (`HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md` → DRAFT 0.3), plus the anchor sync in the master spec.

| # | Finding | Fix |
|---|---|---|
| 1 (HIGH) | Slice A measured only `alive==0` hard-down, blind to the real degradation disease (Groq 401 → Gemini 429 → Mistral 400) | §5 rewritten: per-cycle `calls_delta`/`fail_delta` `degraded` predicate drives the streak alongside hard-down |
| 2 (HIGH) | Non-atomic health write treated as mere hygiene | wired as explicit **Slice-C blocker (iii)** in §8 |
| 3 (HIGH) | Disk read-before-overwrite roundtrip untested | added `test_roundtrip_increment` + `test_roundtrip_missing_and_torn` (§6) |
| 4 (MED) | Double-increment ambiguity | §5.2 extraction-only, §5.3 single increment site |
| 5 (MED) | Threshold unit unclear | §10.1 clarified: cycles, run-jump aware |
| 6 (LOW) | §5.1 vs §5.3 normativity | §5.1 marked illustrative, None-guard only in §5.3 |

Review trail recorded in FEATURE-01 §12.

## Scope / safety

- **Documentation only** — no product code, no workflow changes.
- Isolated to `specs/HEARTBEAT_FAILURE_PROPAGATION_*` — does not touch Phase-2 docs or context-bridge paths.
- All load-bearing recon facts were independently code-verified (12/12) in the prior review round.
- Status remains **DRAFT 0.3 — NOT G1**; implementation/activation gated pending a re-review of the new §5.3 `degraded` predicate and operator go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSHenN8BjubGZe2VUghbyR

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSHenN8BjubGZe2VUghbyR)_