### PR TITLE
feat: add isolated D2b publication primitive

### DIFF
--- a/steward/context_publication.py
+++ b/steward/context_publication.py
@@ -209,7 +209,9 @@ class PublisherLease:
                 return False
             if _directory_anchor(self._steward_fd) != self._steward_anchor:
                 return False
-            return _same_identity(self._lock.identity, _identity(os.fstat(self._lock.descriptor)))
+            lock_identity = _identity(os.fstat(self._lock.descriptor))
+            path_identity = _identity(os.stat(_LOCK, dir_fd=self._steward_fd, follow_symlinks=False))
+            return _same_identity(self._lock.identity, lock_identity) and _same_identity(lock_identity, path_identity)
         except (OSError, ValueError):
             return False
 
@@ -665,7 +667,12 @@ def _journal_template(
     }
 
 
-def _write_journal(descriptor: int, steward_fd: int, journal: Mapping[str, object]) -> None:
+def _write_journal(
+    descriptor: int,
+    steward_fd: int,
+    journal: Mapping[str, object],
+    lease: PublisherLease,
+) -> None:
     txid = journal.get("txid")
     if not isinstance(txid, str):
         raise ValueError("journal_txid")
@@ -673,6 +680,8 @@ def _write_journal(descriptor: int, steward_fd: int, journal: Mapping[str, objec
     value = _canonical_json(journal)
     if len(value) > _JOURNAL_MAX_BYTES:
         raise ValueError("journal_size")
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
     expected = journal["journal"]
     if not isinstance(expected, Mapping) or not _same_identity(expected, _identity(os.fstat(descriptor))):
         raise ValueError("journal_replaced")
@@ -681,6 +690,8 @@ def _write_journal(descriptor: int, steward_fd: int, journal: Mapping[str, objec
     _write_all(descriptor, value)
     os.fsync(descriptor)
     os.fsync(steward_fd)
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
 
 
 def _validate_journal_schema(parsed: object, journal_name: str) -> dict[str, object]:
@@ -859,9 +870,13 @@ def _prepare_temp(
     journal: dict[str, object],
     path: str,
     data: bytes,
+    lease: PublisherLease,
 ) -> None:
     parent_kind, name = _temp_name(path, journal["txid"])
     parent_fd = root_fd if parent_kind == 0 else steward_fd
+    prior_parent = _parent_identity(parent_fd)
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
     descriptor = os.open(
         name,
         os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
@@ -882,27 +897,36 @@ def _prepare_temp(
         raise ValueError("temp_changed")
     os.fsync(parent_fd)
     journal["temps"][path] = {**temp_identity, "candidate_sha256": hashlib.sha256(data).hexdigest()}
-    _refresh_parent_bindings(journal, root_fd, steward_fd, parent_fd)
-    _write_journal(journal_fd, steward_fd, journal)
+    _advance_parent_bindings_after_own_mutation(journal, root_fd, steward_fd, parent_fd, prior_parent)
+    _write_journal(journal_fd, steward_fd, journal, lease)
 
 
-def _refresh_parent_bindings(
+def _advance_parent_bindings_after_own_mutation(
     journal: dict[str, object],
     root_fd: int,
     steward_fd: int,
     parent_fd: int,
+    prior_parent: Mapping[str, int | str],
 ) -> None:
     current_parent = _parent_identity(parent_fd)
+    if not all(current_parent.get(key) == prior_parent.get(key) for key in ("device", "inode", "type", "mode")):
+        raise ValueError("parent_changed")
     targets = journal["targets"]
     for target_path in _TARGETS:
         target_parent_fd, _ = _parent_fd(root_fd, steward_fd, target_path)
         if target_parent_fd == parent_fd:
-            targets[target_path]["parent"] = dict(current_parent)
-            targets[target_path]["baseline"]["parent"] = dict(current_parent)
+            if not _same_identity(targets[target_path]["parent"], prior_parent):
+                raise ValueError("parent_changed")
+            targets[target_path]["parent"]["link_count"] = current_parent["link_count"]
+            targets[target_path]["baseline"]["parent"]["link_count"] = current_parent["link_count"]
     if parent_fd == root_fd:
-        journal["repository"]["root"] = dict(current_parent)
+        if not _same_identity(journal["repository"]["root"], prior_parent):
+            raise ValueError("parent_changed")
+        journal["repository"]["root"]["link_count"] = current_parent["link_count"]
     elif parent_fd == steward_fd:
-        journal["repository"]["steward"] = dict(current_parent)
+        if not _same_identity(journal["repository"]["steward"], prior_parent):
+            raise ValueError("parent_changed")
+        journal["repository"]["steward"]["link_count"] = current_parent["link_count"]
 
 
 def _fence_parent(root_fd: int, steward_fd: int, path: str, expected: Mapping[str, object]) -> int:
@@ -954,6 +978,9 @@ def _replace_one(
     candidates: PublicationCandidates,
     index: int,
     lease: PublisherLease,
+    git_fd: int,
+    attestation: ConstitutionAttestation,
+    expected_git_view: _View,
 ) -> None:
     path = _TARGETS[index]
     txid = journal["txid"]
@@ -971,9 +998,13 @@ def _replace_one(
         or temp.data != _candidate_bytes(candidates, path)
     ):
         raise ValueError("temp_changed")
+    _fence_parent(root_fd, steward_fd, path, record["parent"])
+    prior_parent = _parent_identity(parent_fd)
+    current_git = _view(root_fd, git_fd, steward_fd, attestation, _safe_git()[0], lease.deadline)
+    if not _same_git_view(expected_git_view, current_git):
+        raise ValueError("git_changed_before_replace")
     if not lease.verify():
         raise ValueError("publisher_lease_changed")
-    _fence_parent(root_fd, steward_fd, path, record["parent"])
     target_name = path.removeprefix(".steward/")
     os.replace(temp_name, target_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
     descriptor = os.open(target_name, _OPEN_FILE, dir_fd=parent_fd)
@@ -986,7 +1017,7 @@ def _replace_one(
     if installed is None or installed.data != _candidate_bytes(candidates, path):
         raise ValueError("readback_failed")
     os.fsync(parent_fd)
-    _refresh_parent_bindings(journal, root_fd, steward_fd, parent_fd)
+    _advance_parent_bindings_after_own_mutation(journal, root_fd, steward_fd, parent_fd, prior_parent)
     if not lease.verify():
         raise ValueError("publisher_lease_changed")
     record["installed"] = {**installed.identity, "candidate_sha256": hashlib.sha256(installed.data).hexdigest()}
@@ -999,7 +1030,7 @@ def _replace_one(
     else:
         journal["status"] = "replaced"
         journal["in_flight_target"] = None
-    _write_journal(journal_fd, steward_fd, journal)
+    _write_journal(journal_fd, steward_fd, journal, lease)
 
 
 def _cleanup_transaction(
@@ -1008,7 +1039,11 @@ def _cleanup_transaction(
     journal_fd: int,
     journal: Mapping[str, object],
     parent_fences: Mapping[int, Mapping[str, int | str]] | None = None,
+    *,
+    lease: PublisherLease,
 ) -> None:
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
     _validate_transaction_namespace(root_fd, steward_fd, journal)
     txid = journal["txid"]
     active_parent_fences: dict[int, dict[str, int | str]] = {
@@ -1034,8 +1069,12 @@ def _cleanup_transaction(
         _require_owned_file(parent_fd, name)
         if state is None or not _same_stat_identity(expected, state.identity):
             raise ValueError("temp_cleanup_identity")
+        if not lease.verify():
+            raise ValueError("publisher_lease_changed")
         os.unlink(name, dir_fd=parent_fd)
         os.fsync(parent_fd)
+        if not lease.verify():
+            raise ValueError("publisher_lease_changed")
         active_parent_fences[parent_key] = _parent_identity(parent_fd)
     identity = journal["journal"]
     if not _same_identity(identity, _identity(os.fstat(journal_fd))):
@@ -1044,8 +1083,12 @@ def _cleanup_transaction(
         active_parent_fences[int(steward_fd)] = _parent_identity(steward_fd)
     if not _same_identity(_parent_identity(steward_fd), active_parent_fences[int(steward_fd)]):
         raise ValueError("repository_parent_changed")
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
     os.unlink(f".context-publish-v1.{txid}.txn", dir_fd=steward_fd)
     os.fsync(steward_fd)
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
 
 
 def _create_transaction(
@@ -1058,10 +1101,14 @@ def _create_transaction(
     lease: PublisherLease,
 ) -> PublicationResult:
     txid = secrets.token_hex(16)
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
     journals, temps, unknown = _scan_namespace(root_fd, steward_fd)
     if journals or temps or unknown:
         raise ValueError("transaction_namespace_ambiguous")
     name = f".context-publish-v1.{txid}.txn"
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
     journal_fd = os.open(
         name,
         os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
@@ -1069,18 +1116,31 @@ def _create_transaction(
         dir_fd=steward_fd,
     )
     try:
+        if not lease.verify():
+            raise ValueError("publisher_lease_changed")
         journal_identity = _identity(os.fstat(journal_fd))
         journal = _journal_template(txid, journal_identity, root_fd, git_fd, steward_fd, view, candidates, attestation)
-        _write_journal(journal_fd, steward_fd, journal)
+        _write_journal(journal_fd, steward_fd, journal, lease)
         for path in _TARGETS:
-            _prepare_temp(root_fd, steward_fd, journal_fd, journal, path, _candidate_bytes(candidates, path))
+            _prepare_temp(root_fd, steward_fd, journal_fd, journal, path, _candidate_bytes(candidates, path), lease)
         _validate_transaction_namespace(root_fd, steward_fd, journal)
         for index in range(len(_TARGETS)):
             if not lease.verify():
                 raise ValueError("publisher_lease_changed")
             _validate_transaction_namespace(root_fd, steward_fd, journal)
             _fence_targets(root_fd, steward_fd, journal, candidates, index)
-            _replace_one(root_fd, steward_fd, journal_fd, journal, candidates, index, lease)
+            _replace_one(
+                root_fd,
+                steward_fd,
+                journal_fd,
+                journal,
+                candidates,
+                index,
+                lease,
+                git_fd,
+                attestation,
+                view,
+            )
             current = _view(root_fd, git_fd, steward_fd, attestation, _safe_git()[0], lease.deadline)
             if not _same_git_view(view, current):
                 raise ValueError("git_changed_during_transaction")
@@ -1090,8 +1150,8 @@ def _create_transaction(
         if not _same_git_view(view, current) or not lease.verify():
             raise ValueError("final_transaction_fence")
         journal["status"] = "read_back_validated"
-        _write_journal(journal_fd, steward_fd, journal)
-        _cleanup_transaction(root_fd, steward_fd, journal_fd, journal)
+        _write_journal(journal_fd, steward_fd, journal, lease)
+        _cleanup_transaction(root_fd, steward_fd, journal_fd, journal, lease=lease)
         return _result(PublicationState.PUBLISHED, "published", txid)
     except (OSError, ValueError, ContractViolation, TimeoutError, observer._ObservationFailure) as error:
         return _result(PublicationState.MANUAL_REVIEW, type(error).__name__.lower(), txid)
@@ -1225,9 +1285,12 @@ def _prepare_recovery_temp(
     journal: Mapping[str, object],
     path: str,
     data: bytes,
+    lease: PublisherLease,
 ) -> tuple[int, str]:
     parent_kind, name = _temp_name(path, journal["txid"])
     parent_fd = root_fd if parent_kind == 0 else steward_fd
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
     if _safe_file_state(parent_fd, name, PERSISTED_TARGET_MAX_BYTES[path]) is not None:
         raise ValueError("recovery_temp_present")
     descriptor = os.open(
@@ -1255,6 +1318,8 @@ def _prepare_recovery_temp(
     if check is None or check.data != data or check.identity != identity:
         raise ValueError("recovery_temp_changed")
     os.fsync(parent_fd)
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
     return parent_fd, name
 
 
@@ -1286,14 +1351,20 @@ def _rollback_partial_transaction(
         data = _baseline_bytes(view, journal, path)
         parent_fd, target_name = _parent_fd(root_fd, steward_fd, path)
         if data is None:
+            if not lease.verify():
+                raise ValueError("publisher_lease_changed")
             os.unlink(target_name, dir_fd=parent_fd)
             os.fsync(parent_fd)
+            if not lease.verify():
+                raise ValueError("publisher_lease_changed")
             if _safe_file_state(parent_fd, target_name, PERSISTED_TARGET_MAX_BYTES[path]) is not None:
                 raise ValueError("recovery_unlink_failed")
         else:
-            _, temp_name = _prepare_recovery_temp(root_fd, steward_fd, journal, path, data)
+            _, temp_name = _prepare_recovery_temp(root_fd, steward_fd, journal, path, data, lease)
             parent_states[int(parent_fd)] = _parent_identity(parent_fd)
             _fence_recovery_state(root_fd, steward_fd, journal, candidates, view, cursor, restored, parent_states)
+            if not lease.verify():
+                raise ValueError("publisher_lease_changed")
             os.replace(temp_name, target_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
             descriptor = os.open(target_name, _OPEN_FILE, dir_fd=parent_fd)
             try:
@@ -1308,31 +1379,39 @@ def _rollback_partial_transaction(
                 or restored_state.identity["mode"] != baseline["mode"]
             ):
                 raise ValueError("recovery_readback_failed")
+            os.fsync(parent_fd)
+            if not lease.verify():
+                raise ValueError("publisher_lease_changed")
         parent_states[int(parent_fd)] = _parent_identity(parent_fd)
         restored.add(path)
         current = _view(root_fd, git_fd, steward_fd, attestation, _safe_git()[0], deadline)
         if not _same_git_view(view, current) or not lease.verify():
             raise ValueError("git_changed_during_recovery")
     _fence_recovery_state(root_fd, steward_fd, journal, candidates, view, cursor, restored, parent_states)
-    _cleanup_transaction(root_fd, steward_fd, journal_fd, journal, parent_states)
+    _cleanup_transaction(root_fd, steward_fd, journal_fd, journal, parent_states, lease=lease)
     return _result(PublicationState.BLOCKED, "recovered_rollback", journal["txid"])
 
 
-def _validate_recovery_view_state(status: object, state: observer.GenerationState) -> None:
+def _validate_recovery_view_state(status: object, view: _View) -> None:
+    if status == "replacing":
+        if view.tree != view.index:
+            raise ValueError("recovery_git_state_untrusted")
+        if view.reason not in {
+            "partial_generated_state",
+            "generation_contract_invalid",
+            "generation_not_head_bound",
+            "head_bound_generation_valid",
+            "all_targets_absent",
+            "transaction_generation_present",
+        }:
+            raise ValueError("recovery_state_untrusted")
+        return
     allowed = {
         "prepared": {observer.GenerationState.ABSENT, observer.GenerationState.VALID},
-        "replacing": {
-            observer.GenerationState.MIXED,
-            observer.GenerationState.UNBOUND,
-            observer.GenerationState.VALID,
-            observer.GenerationState.ABSENT,
-            observer.GenerationState.INVALID,
-            observer.GenerationState.MANUAL_REVIEW,
-        },
         "replaced": {observer.GenerationState.VALID, observer.GenerationState.UNBOUND},
         "read_back_validated": {observer.GenerationState.VALID, observer.GenerationState.UNBOUND},
     }
-    if state not in allowed.get(status, set()):
+    if view.state not in allowed.get(status, set()):
         raise ValueError("recovery_state_untrusted")
 
 
@@ -1389,7 +1468,7 @@ def _recover_existing(
         _validate_transaction_namespace(root_fd, steward_fd, journal)
         git, _ = _safe_git()
         view = _view(root_fd, git_fd, steward_fd, attestation, git, deadline)
-        _validate_recovery_view_state(journal["status"], view.state)
+        _validate_recovery_view_state(journal["status"], view)
         _validate_journal_binding(root_fd, git_fd, steward_fd, journal, candidates, attestation, view)
         _validate_transaction_files(root_fd, steward_fd, journal)
         status = journal.get("status")
@@ -1399,14 +1478,14 @@ def _recover_existing(
             current = _view(root_fd, git_fd, steward_fd, attestation, _safe_git()[0], deadline)
             if not _same_git_view(view, current) or not lease.verify():
                 raise ValueError("git_changed_during_recovery")
-            _cleanup_transaction(root_fd, steward_fd, journal_fd, journal)
+            _cleanup_transaction(root_fd, steward_fd, journal_fd, journal, lease=lease)
             return _result(PublicationState.BLOCKED, "recovered_prepared", journal["txid"])
         if status in {"replaced", "read_back_validated"} and cursor == 4:
             _fence_targets(root_fd, steward_fd, journal, candidates, 4)
             current = _view(root_fd, git_fd, steward_fd, attestation, _safe_git()[0], deadline)
             if not _same_git_view(view, current) or not lease.verify():
                 raise ValueError("git_changed_during_recovery")
-            _cleanup_transaction(root_fd, steward_fd, journal_fd, journal)
+            _cleanup_transaction(root_fd, steward_fd, journal_fd, journal, lease=lease)
             return _result(PublicationState.PUBLISHED, "recovered_generation", journal["txid"])
         if status == "replacing" and isinstance(cursor, int) and 1 <= cursor <= 3:
             return _rollback_partial_transaction(

--- a/steward/context_publication.py
+++ b/steward/context_publication.py
@@ -79,6 +79,7 @@ _OPEN_FILE = observer._OPEN_FILE
 
 _THREAD_LOCK_GUARD = threading.Lock()
 _THREAD_LOCKS: dict[tuple[int, int], threading.Lock] = {}
+_LEASE_TOKEN = object()
 
 
 class PublicationMode(str, Enum):
@@ -136,6 +137,94 @@ class _HeldLock:
             self.thread_lock.release()
 
 
+class PublisherLease:
+    """Private-worktree capability required for canonical publication."""
+
+    __slots__ = (
+        "_repository_root",
+        "_root_fd",
+        "_git_fd",
+        "_steward_fd",
+        "_lock",
+        "_root_anchor",
+        "_git_anchor",
+        "_steward_anchor",
+        "_pid",
+        "_deadline",
+        "_closed",
+        "_token",
+    )
+
+    def __init__(
+        self,
+        token: object,
+        repository_root: Path,
+        root_fd: int,
+        git_fd: int,
+        steward_fd: int,
+        lock: _HeldLock,
+        anchors: tuple[tuple[int, int, int, int], tuple[int, int, int, int], tuple[int, int, int, int]],
+        deadline: float,
+    ) -> None:
+        if token is not _LEASE_TOKEN:
+            raise TypeError("lease_constructor_private")
+        self._token = token
+        self._repository_root = repository_root
+        self._root_fd = root_fd
+        self._git_fd = git_fd
+        self._steward_fd = steward_fd
+        self._lock = lock
+        self._root_anchor, self._git_anchor, self._steward_anchor = anchors
+        self._pid = os.getpid()
+        self._deadline = deadline
+        self._closed = False
+
+    @property
+    def repository_root(self) -> Path:
+        return self._repository_root
+
+    @property
+    def root_fd(self) -> int:
+        return self._root_fd
+
+    @property
+    def git_fd(self) -> int:
+        return self._git_fd
+
+    @property
+    def steward_fd(self) -> int:
+        return self._steward_fd
+
+    @property
+    def deadline(self) -> float:
+        return self._deadline
+
+    def verify(self) -> bool:
+        if self._closed or os.getpid() != self._pid or time.monotonic() >= self._deadline:
+            return False
+        try:
+            if _directory_anchor(self._root_fd) != self._root_anchor:
+                return False
+            if _directory_anchor(self._git_fd) != self._git_anchor:
+                return False
+            if _directory_anchor(self._steward_fd) != self._steward_anchor:
+                return False
+            return _same_identity(self._lock.identity, _identity(os.fstat(self._lock.descriptor)))
+        except (OSError, ValueError):
+            return False
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._lock.close()
+        for descriptor in (self._git_fd, self._steward_fd, self._root_fd):
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
 def _result(state: PublicationState, reason: str, txid: str | None = None) -> PublicationResult:
     return PublicationResult(state, reason[:160], txid)
 
@@ -174,6 +263,13 @@ def _identity(value: os.stat_result, *, include_size: bool = False) -> dict[str,
     if include_size:
         result["size"] = int(value.st_size)
     return result
+
+
+def _directory_anchor(descriptor: int) -> tuple[int, int, int, int]:
+    value = os.fstat(descriptor)
+    if not stat.S_ISDIR(value.st_mode) or value.st_uid != os.geteuid() or value.st_mode & 0o022:
+        raise ValueError("unsafe_directory_anchor")
+    return (value.st_dev, value.st_ino, stat.S_IFMT(value.st_mode), stat.S_IMODE(value.st_mode))
 
 
 def _same_identity(expected: Mapping[str, object], actual: Mapping[str, object]) -> bool:
@@ -363,6 +459,40 @@ def _acquire_lock(steward_fd: int, deadline: float) -> _HeldLock:
         raise
 
 
+def acquire_publisher_lease(repository_root: Path) -> PublisherLease:
+    """Acquire a pinned, private-worktree publication capability."""
+    if not isinstance(repository_root, Path) or not repository_root.is_absolute():
+        raise ValueError("repository_path_invalid")
+    root_fd = steward_fd = git_fd = None
+    lock: _HeldLock | None = None
+    deadline = time.monotonic() + _DEADLINE_SECONDS
+    try:
+        root_fd = observer._open_repository_root(repository_root)
+        steward_fd = _open_steward(root_fd)
+        git_fd = _open_git(root_fd)
+        _directory_anchor(root_fd)
+        _directory_anchor(steward_fd)
+        _directory_anchor(git_fd)
+        _safe_git()
+        lock = _acquire_lock(steward_fd, deadline)
+        anchors = (
+            _directory_anchor(root_fd),
+            _directory_anchor(git_fd),
+            _directory_anchor(steward_fd),
+        )
+        return PublisherLease(_LEASE_TOKEN, repository_root, root_fd, git_fd, steward_fd, lock, anchors, deadline)
+    except Exception:
+        if lock is not None:
+            lock.close()
+        for descriptor in (git_fd, steward_fd, root_fd):
+            if descriptor is not None:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+        raise
+
+
 def _scan_namespace(root_fd: int, steward_fd: int) -> tuple[list[str], list[str], bool]:
     journals: list[str] = []
     temps: list[str] = []
@@ -423,6 +553,16 @@ def _same_view(left: _View, right: _View) -> bool:
     )
 
 
+def _same_git_view(left: _View, right: _View) -> bool:
+    return (
+        left.head == right.head
+        and left.tree == right.tree
+        and left.index == right.index
+        and left.head_blobs == right.head_blobs
+        and left.layout == right.layout
+    )
+
+
 def _candidate_metadata(candidates: PublicationCandidates) -> tuple[str, str, str]:
     snapshot = json.loads(candidates.snapshot_artifact.decode("utf-8"))
     publication = json.loads(candidates.publication_artifact.decode("utf-8"))
@@ -456,6 +596,9 @@ def _target_baseline(
         }
     if tree_target is None or head_bytes is None or current.data != head_bytes:
         raise ValueError("baseline_unbound")
+    expected_mode = int(tree_target.mode, 8) & 0o777
+    if current.identity["mode"] != expected_mode:
+        raise ValueError("baseline_mode_unexpected")
     return {
         "parent": dict(parent_identity),
         "target": dict(current.identity),
@@ -737,21 +880,35 @@ def _prepare_temp(
     check = _safe_file_state(parent_fd, name, PERSISTED_TARGET_MAX_BYTES[path])
     if check is None or check.data != data or check.identity != temp_identity:
         raise ValueError("temp_changed")
+    os.fsync(parent_fd)
     journal["temps"][path] = {**temp_identity, "candidate_sha256": hashlib.sha256(data).hexdigest()}
+    _refresh_parent_bindings(journal, root_fd, steward_fd, parent_fd)
+    _write_journal(journal_fd, steward_fd, journal)
+
+
+def _refresh_parent_bindings(
+    journal: dict[str, object],
+    root_fd: int,
+    steward_fd: int,
+    parent_fd: int,
+) -> None:
     current_parent = _parent_identity(parent_fd)
+    targets = journal["targets"]
     for target_path in _TARGETS:
         target_parent_fd, _ = _parent_fd(root_fd, steward_fd, target_path)
         if target_parent_fd == parent_fd:
-            journal["targets"][target_path]["parent"] = dict(current_parent)
-            journal["targets"][target_path]["baseline"]["parent"] = dict(current_parent)
-    journal["repository"]["root"] = _parent_identity(root_fd)
-    journal["repository"]["steward"] = _parent_identity(steward_fd)
-    _write_journal(journal_fd, steward_fd, journal)
+            targets[target_path]["parent"] = dict(current_parent)
+            targets[target_path]["baseline"]["parent"] = dict(current_parent)
+    if parent_fd == root_fd:
+        journal["repository"]["root"] = dict(current_parent)
+    elif parent_fd == steward_fd:
+        journal["repository"]["steward"] = dict(current_parent)
 
 
 def _fence_parent(root_fd: int, steward_fd: int, path: str, expected: Mapping[str, object]) -> int:
     parent_fd, _ = _parent_fd(root_fd, steward_fd, path)
-    if not _same_identity(expected, _parent_identity(parent_fd)):
+    current = _parent_identity(parent_fd)
+    if not _same_identity(expected, current):
         raise ValueError("parent_changed")
     return parent_fd
 
@@ -796,6 +953,7 @@ def _replace_one(
     journal: dict[str, object],
     candidates: PublicationCandidates,
     index: int,
+    lease: PublisherLease,
 ) -> None:
     path = _TARGETS[index]
     txid = journal["txid"]
@@ -813,6 +971,8 @@ def _replace_one(
         or temp.data != _candidate_bytes(candidates, path)
     ):
         raise ValueError("temp_changed")
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
     _fence_parent(root_fd, steward_fd, path, record["parent"])
     target_name = path.removeprefix(".steward/")
     os.replace(temp_name, target_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
@@ -825,6 +985,10 @@ def _replace_one(
         os.close(descriptor)
     if installed is None or installed.data != _candidate_bytes(candidates, path):
         raise ValueError("readback_failed")
+    os.fsync(parent_fd)
+    _refresh_parent_bindings(journal, root_fd, steward_fd, parent_fd)
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
     record["installed"] = {**installed.identity, "candidate_sha256": hashlib.sha256(installed.data).hexdigest()}
     journal["installed_targets"][path] = record["installed"]
     journal["cursor"] = index + 1
@@ -836,13 +1000,20 @@ def _replace_one(
         journal["status"] = "replaced"
         journal["in_flight_target"] = None
     _write_journal(journal_fd, steward_fd, journal)
-    os.fsync(parent_fd)
 
 
-def _cleanup_transaction(root_fd: int, steward_fd: int, journal_fd: int, journal: Mapping[str, object]) -> None:
+def _cleanup_transaction(
+    root_fd: int,
+    steward_fd: int,
+    journal_fd: int,
+    journal: Mapping[str, object],
+    parent_fences: Mapping[int, Mapping[str, int | str]] | None = None,
+) -> None:
     _validate_transaction_namespace(root_fd, steward_fd, journal)
     txid = journal["txid"]
-    parent_fences: dict[int, dict[str, int | str]] = {}
+    active_parent_fences: dict[int, dict[str, int | str]] = {
+        int(key): dict(value) for key, value in (parent_fences or {}).items()
+    }
     for path in _TARGETS:
         parent_kind, name = _temp_name(path, txid)
         parent_fd = root_fd if parent_kind == 0 else steward_fd
@@ -851,27 +1022,27 @@ def _cleanup_transaction(root_fd: int, steward_fd: int, journal_fd: int, journal
             continue
         current_parent = _parent_identity(parent_fd)
         parent_key = int(parent_fd)
-        if parent_key not in parent_fences:
+        if parent_key not in active_parent_fences:
             if not _same_identity(current_parent, journal["targets"][path]["parent"]):
                 raise ValueError("parent_changed")
-        elif not _same_identity(current_parent, parent_fences[parent_key]):
+        elif not _same_identity(current_parent, active_parent_fences[parent_key]):
             raise ValueError("parent_changed")
         state = _safe_file_state(parent_fd, name, PERSISTED_TARGET_MAX_BYTES[path])
         if state is None and path in journal["installed_targets"]:
-            parent_fences[parent_key] = current_parent
+            active_parent_fences[parent_key] = current_parent
             continue
         _require_owned_file(parent_fd, name)
         if state is None or not _same_stat_identity(expected, state.identity):
             raise ValueError("temp_cleanup_identity")
         os.unlink(name, dir_fd=parent_fd)
         os.fsync(parent_fd)
-        parent_fences[parent_key] = _parent_identity(parent_fd)
+        active_parent_fences[parent_key] = _parent_identity(parent_fd)
     identity = journal["journal"]
     if not _same_identity(identity, _identity(os.fstat(journal_fd))):
         raise ValueError("journal_cleanup_identity")
-    if int(steward_fd) not in parent_fences:
-        parent_fences[int(steward_fd)] = _parent_identity(steward_fd)
-    if not _same_identity(_parent_identity(steward_fd), parent_fences[int(steward_fd)]):
+    if int(steward_fd) not in active_parent_fences:
+        active_parent_fences[int(steward_fd)] = _parent_identity(steward_fd)
+    if not _same_identity(_parent_identity(steward_fd), active_parent_fences[int(steward_fd)]):
         raise ValueError("repository_parent_changed")
     os.unlink(f".context-publish-v1.{txid}.txn", dir_fd=steward_fd)
     os.fsync(steward_fd)
@@ -884,8 +1055,12 @@ def _create_transaction(
     view: _View,
     candidates: PublicationCandidates,
     attestation: ConstitutionAttestation,
+    lease: PublisherLease,
 ) -> PublicationResult:
     txid = secrets.token_hex(16)
+    journals, temps, unknown = _scan_namespace(root_fd, steward_fd)
+    if journals or temps or unknown:
+        raise ValueError("transaction_namespace_ambiguous")
     name = f".context-publish-v1.{txid}.txn"
     journal_fd = os.open(
         name,
@@ -901,11 +1076,19 @@ def _create_transaction(
             _prepare_temp(root_fd, steward_fd, journal_fd, journal, path, _candidate_bytes(candidates, path))
         _validate_transaction_namespace(root_fd, steward_fd, journal)
         for index in range(len(_TARGETS)):
+            if not lease.verify():
+                raise ValueError("publisher_lease_changed")
             _validate_transaction_namespace(root_fd, steward_fd, journal)
             _fence_targets(root_fd, steward_fd, journal, candidates, index)
-            _replace_one(root_fd, steward_fd, journal_fd, journal, candidates, index)
+            _replace_one(root_fd, steward_fd, journal_fd, journal, candidates, index, lease)
+            current = _view(root_fd, git_fd, steward_fd, attestation, _safe_git()[0], lease.deadline)
+            if not _same_git_view(view, current):
+                raise ValueError("git_changed_during_transaction")
         _validate_transaction_namespace(root_fd, steward_fd, journal)
         _fence_targets(root_fd, steward_fd, journal, candidates, len(_TARGETS))
+        current = _view(root_fd, git_fd, steward_fd, attestation, _safe_git()[0], lease.deadline)
+        if not _same_git_view(view, current) or not lease.verify():
+            raise ValueError("final_transaction_fence")
         journal["status"] = "read_back_validated"
         _write_journal(journal_fd, steward_fd, journal)
         _cleanup_transaction(root_fd, steward_fd, journal_fd, journal)
@@ -969,6 +1152,190 @@ def _validate_transaction_files(root_fd: int, steward_fd: int, journal: Mapping[
             raise ValueError("temp_foreign")
 
 
+def _parent_state_matches(
+    root_fd: int,
+    steward_fd: int,
+    path: str,
+    expected: Mapping[str, int | str],
+) -> int:
+    parent_fd, _ = _parent_fd(root_fd, steward_fd, path)
+    if not _same_identity(_parent_identity(parent_fd), expected):
+        raise ValueError("recovery_parent_changed")
+    return parent_fd
+
+
+def _baseline_bytes(view: _View, journal: Mapping[str, object], path: str) -> bytes | None:
+    baseline = journal["targets"][path]["baseline"]
+    if not baseline["present"]:
+        return None
+    data = view.head_blobs.get(path)
+    if data is None or hashlib.sha256(data).hexdigest() != baseline["sha256"] or len(data) != baseline["size"]:
+        raise ValueError("recovery_baseline_unavailable")
+    return data
+
+
+def _fence_recovery_state(
+    root_fd: int,
+    steward_fd: int,
+    journal: Mapping[str, object],
+    candidates: PublicationCandidates,
+    view: _View,
+    cursor: int,
+    restored: set[str],
+    parent_states: Mapping[int, Mapping[str, int | str]],
+) -> None:
+    for index, path in enumerate(_TARGETS):
+        record = journal["targets"][path]
+        parent_fd, _ = _parent_fd(root_fd, steward_fd, path)
+        parent_key = int(parent_fd)
+        expected_parent = parent_states.get(parent_key, record["parent"])
+        _parent_state_matches(root_fd, steward_fd, path, expected_parent)
+        baseline = record["baseline"]
+        state = _safe_file_state(parent_fd, path.removeprefix(".steward/"), PERSISTED_TARGET_MAX_BYTES[path])
+        if path in restored:
+            expected_data = _baseline_bytes(view, journal, path)
+            if expected_data is None:
+                if state is not None:
+                    raise ValueError("recovery_target_present")
+            elif state is None or state.data != expected_data or state.identity["mode"] != baseline["mode"]:
+                raise ValueError("recovery_baseline_changed")
+        elif index < cursor:
+            installed = record["installed"]
+            if (
+                state is None
+                or installed is None
+                or not _same_stat_identity(installed, state.identity)
+                or state.data != _candidate_bytes(candidates, path)
+            ):
+                raise ValueError("recovery_candidate_changed")
+        elif baseline["present"]:
+            if (
+                state is None
+                or not _same_stat_identity(baseline["target"], state.identity)
+                or hashlib.sha256(state.data).hexdigest() != baseline["sha256"]
+            ):
+                raise ValueError("recovery_suffix_changed")
+        elif state is not None:
+            raise ValueError("recovery_suffix_present")
+
+
+def _prepare_recovery_temp(
+    root_fd: int,
+    steward_fd: int,
+    journal: Mapping[str, object],
+    path: str,
+    data: bytes,
+) -> tuple[int, str]:
+    parent_kind, name = _temp_name(path, journal["txid"])
+    parent_fd = root_fd if parent_kind == 0 else steward_fd
+    if _safe_file_state(parent_fd, name, PERSISTED_TARGET_MAX_BYTES[path]) is not None:
+        raise ValueError("recovery_temp_present")
+    descriptor = os.open(
+        name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+        0o600,
+        dir_fd=parent_fd,
+    )
+    try:
+        _write_all(descriptor, data)
+        os.fsync(descriptor)
+        value = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(value.st_mode)
+            or value.st_nlink != 1
+            or stat.S_IMODE(value.st_mode) != 0o600
+            or value.st_uid != os.geteuid()
+            or value.st_size != len(data)
+        ):
+            raise ValueError("recovery_temp_unsafe")
+        identity = _identity(value, include_size=True)
+    finally:
+        os.close(descriptor)
+    check = _safe_file_state(parent_fd, name, PERSISTED_TARGET_MAX_BYTES[path])
+    if check is None or check.data != data or check.identity != identity:
+        raise ValueError("recovery_temp_changed")
+    os.fsync(parent_fd)
+    return parent_fd, name
+
+
+def _rollback_partial_transaction(
+    root_fd: int,
+    git_fd: int,
+    steward_fd: int,
+    journal_fd: int,
+    journal: Mapping[str, object],
+    candidates: PublicationCandidates,
+    attestation: ConstitutionAttestation,
+    view: _View,
+    lease: PublisherLease,
+    deadline: float,
+) -> PublicationResult:
+    cursor = journal["cursor"]
+    _fence_targets(root_fd, steward_fd, journal, candidates, cursor)
+    restored: set[str] = set()
+    parent_states = {
+        int(root_fd): _parent_identity(root_fd),
+        int(steward_fd): _parent_identity(steward_fd),
+    }
+    for index in reversed(range(cursor)):
+        if not lease.verify():
+            raise ValueError("publisher_lease_changed")
+        _fence_recovery_state(root_fd, steward_fd, journal, candidates, view, cursor, restored, parent_states)
+        path = _TARGETS[index]
+        baseline = journal["targets"][path]["baseline"]
+        data = _baseline_bytes(view, journal, path)
+        parent_fd, target_name = _parent_fd(root_fd, steward_fd, path)
+        if data is None:
+            os.unlink(target_name, dir_fd=parent_fd)
+            os.fsync(parent_fd)
+            if _safe_file_state(parent_fd, target_name, PERSISTED_TARGET_MAX_BYTES[path]) is not None:
+                raise ValueError("recovery_unlink_failed")
+        else:
+            _, temp_name = _prepare_recovery_temp(root_fd, steward_fd, journal, path, data)
+            parent_states[int(parent_fd)] = _parent_identity(parent_fd)
+            _fence_recovery_state(root_fd, steward_fd, journal, candidates, view, cursor, restored, parent_states)
+            os.replace(temp_name, target_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            descriptor = os.open(target_name, _OPEN_FILE, dir_fd=parent_fd)
+            try:
+                os.fchmod(descriptor, baseline["mode"])
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+            restored_state = _safe_file_state(parent_fd, target_name, PERSISTED_TARGET_MAX_BYTES[path])
+            if (
+                restored_state is None
+                or restored_state.data != data
+                or restored_state.identity["mode"] != baseline["mode"]
+            ):
+                raise ValueError("recovery_readback_failed")
+        parent_states[int(parent_fd)] = _parent_identity(parent_fd)
+        restored.add(path)
+        current = _view(root_fd, git_fd, steward_fd, attestation, _safe_git()[0], deadline)
+        if not _same_git_view(view, current) or not lease.verify():
+            raise ValueError("git_changed_during_recovery")
+    _fence_recovery_state(root_fd, steward_fd, journal, candidates, view, cursor, restored, parent_states)
+    _cleanup_transaction(root_fd, steward_fd, journal_fd, journal, parent_states)
+    return _result(PublicationState.BLOCKED, "recovered_rollback", journal["txid"])
+
+
+def _validate_recovery_view_state(status: object, state: observer.GenerationState) -> None:
+    allowed = {
+        "prepared": {observer.GenerationState.ABSENT, observer.GenerationState.VALID},
+        "replacing": {
+            observer.GenerationState.MIXED,
+            observer.GenerationState.UNBOUND,
+            observer.GenerationState.VALID,
+            observer.GenerationState.ABSENT,
+            observer.GenerationState.INVALID,
+            observer.GenerationState.MANUAL_REVIEW,
+        },
+        "replaced": {observer.GenerationState.VALID, observer.GenerationState.UNBOUND},
+        "read_back_validated": {observer.GenerationState.VALID, observer.GenerationState.UNBOUND},
+    }
+    if state not in allowed.get(status, set()):
+        raise ValueError("recovery_state_untrusted")
+
+
 def _validate_journal_binding(
     root_fd: int,
     git_fd: int,
@@ -987,11 +1354,12 @@ def _validate_journal_binding(
         or journal["source_blob"] != attestation.source_blob
     ):
         raise ValueError("journal_binding")
-    if journal["repository"] != {
+    current_repository = {
         "root": _parent_identity(root_fd),
         "git": _parent_identity(git_fd),
         "steward": _parent_identity(steward_fd),
-    }:
+    }
+    if any(not _same_identity(journal["repository"][key], current_repository[key]) for key in current_repository):
         raise ValueError("repository_binding")
     for path in _TARGETS:
         data = _candidate_bytes(candidates, path)
@@ -1008,6 +1376,7 @@ def _recover_existing(
     attestation: ConstitutionAttestation,
     candidates: PublicationCandidates,
     deadline: float,
+    lease: PublisherLease,
 ) -> PublicationResult:
     journals, temps, unknown = _scan_namespace(root_fd, steward_fd)
     if unknown or journals != [journal_name]:
@@ -1020,21 +1389,38 @@ def _recover_existing(
         _validate_transaction_namespace(root_fd, steward_fd, journal)
         git, _ = _safe_git()
         view = _view(root_fd, git_fd, steward_fd, attestation, git, deadline)
+        _validate_recovery_view_state(journal["status"], view.state)
         _validate_journal_binding(root_fd, git_fd, steward_fd, journal, candidates, attestation, view)
         _validate_transaction_files(root_fd, steward_fd, journal)
         status = journal.get("status")
         cursor = journal.get("cursor")
         if status == "prepared" and cursor == 0:
             _fence_targets(root_fd, steward_fd, journal, candidates, 0)
+            current = _view(root_fd, git_fd, steward_fd, attestation, _safe_git()[0], deadline)
+            if not _same_git_view(view, current) or not lease.verify():
+                raise ValueError("git_changed_during_recovery")
             _cleanup_transaction(root_fd, steward_fd, journal_fd, journal)
             return _result(PublicationState.BLOCKED, "recovered_prepared", journal["txid"])
         if status in {"replaced", "read_back_validated"} and cursor == 4:
             _fence_targets(root_fd, steward_fd, journal, candidates, 4)
+            current = _view(root_fd, git_fd, steward_fd, attestation, _safe_git()[0], deadline)
+            if not _same_git_view(view, current) or not lease.verify():
+                raise ValueError("git_changed_during_recovery")
             _cleanup_transaction(root_fd, steward_fd, journal_fd, journal)
             return _result(PublicationState.PUBLISHED, "recovered_generation", journal["txid"])
         if status == "replacing" and isinstance(cursor, int) and 1 <= cursor <= 3:
-            _fence_targets(root_fd, steward_fd, journal, candidates, cursor)
-            return _result(PublicationState.MANUAL_REVIEW, "recovery_requires_review", journal["txid"])
+            return _rollback_partial_transaction(
+                root_fd,
+                git_fd,
+                steward_fd,
+                journal_fd,
+                journal,
+                candidates,
+                attestation,
+                view,
+                lease,
+                deadline,
+            )
         return _result(PublicationState.MANUAL_REVIEW, "recovery_state_invalid", journal["txid"])
     except (OSError, ValueError, ContractViolation, TimeoutError, observer._ObservationFailure) as error:
         return _result(PublicationState.MANUAL_REVIEW, type(error).__name__.lower(), journal.get("txid"))
@@ -1053,7 +1439,7 @@ def publish_context(
     attestation: ConstitutionAttestation,
     *,
     mode: PublicationMode | str = PublicationMode.DISABLED,
-    isolation_attested: bool = False,
+    lease: PublisherLease | None = None,
 ) -> PublicationResult:
     """Publish one validated generation; canonical mode is never caller-wired."""
     try:
@@ -1069,26 +1455,33 @@ def publish_context(
         return _result(PublicationState.BLOCKED, "disabled")
     if selected_mode is PublicationMode.PREVIEW:
         return _result(PublicationState.BLOCKED, "preview_only")
-    if not isolation_attested:
-        return _result(PublicationState.BLOCKED, "isolation_not_attested")
     if not isinstance(repository_root, Path) or not repository_root.is_absolute():
         return _result(PublicationState.BLOCKED, "repository_path_invalid")
-    root_fd = git_fd = steward_fd = None
-    lock: _HeldLock | None = None
-    deadline = time.monotonic() + _DEADLINE_SECONDS
+    if not isinstance(lease, PublisherLease):
+        return _result(PublicationState.BLOCKED, "publisher_lease_required")
+    if lease.repository_root != repository_root or not lease.verify():
+        return _result(PublicationState.BLOCKED, "publisher_lease_invalid")
+    root_fd = lease.root_fd
+    git_fd = lease.git_fd
+    steward_fd = lease.steward_fd
+    deadline = lease.deadline
     try:
-        root_fd = observer._open_repository_root(repository_root)
-        steward_fd = _open_steward(root_fd)
-        git_fd = _open_git(root_fd)
+        if not lease.verify():
+            return _result(PublicationState.MANUAL_REVIEW, "publisher_lease_changed")
         git, _ = _safe_git()
+        # Namespace state is read only after the exclusive lease exists.
         journals, temps, unknown = _scan_namespace(root_fd, steward_fd)
-        lock = _acquire_lock(steward_fd, deadline)
         if unknown or len(journals) > 1:
             return _result(PublicationState.MANUAL_REVIEW, "transaction_namespace_ambiguous")
         if journals or temps:
             if len(journals) != 1:
                 return _result(PublicationState.MANUAL_REVIEW, "transaction_journal_missing")
-            return _recover_existing(root_fd, git_fd, steward_fd, journals[0], attestation, candidates, deadline)
+            result = _recover_existing(
+                root_fd, git_fd, steward_fd, journals[0], attestation, candidates, deadline, lease
+            )
+            if result.state in {PublicationState.PUBLISHED, PublicationState.NO_OP} and not lease.verify():
+                return _result(PublicationState.MANUAL_REVIEW, "publisher_lease_changed", result.transaction_id)
+            return result
         before = _view(root_fd, git_fd, steward_fd, attestation, git, deadline)
         if before.state not in {observer.GenerationState.ABSENT, observer.GenerationState.VALID}:
             return _result(PublicationState.MANUAL_REVIEW, f"baseline_{before.state.value}")
@@ -1100,20 +1493,22 @@ def publish_context(
             for path in _TARGETS:
                 parent_fd, name = _parent_fd(root_fd, steward_fd, path)
                 current_states[path] = _safe_file_state(parent_fd, name, PERSISTED_TARGET_MAX_BYTES[path])
+                current = current_states[path]
+                tree_target = before.tree.get(path)
+                if (
+                    current is not None
+                    and tree_target is not None
+                    and current.identity["mode"] != int(tree_target.mode, 8) & 0o777
+                ):
+                    return _result(PublicationState.MANUAL_REVIEW, "baseline_mode_unexpected")
             if all(
                 current_states[path] is not None and current_states[path].data == _candidate_bytes(candidates, path)
                 for path in _TARGETS
             ):
                 return _result(PublicationState.NO_OP, "already_published")
-        return _create_transaction(root_fd, git_fd, steward_fd, after, candidates, attestation)
+        result = _create_transaction(root_fd, git_fd, steward_fd, after, candidates, attestation, lease)
+        if result.state in {PublicationState.PUBLISHED, PublicationState.NO_OP} and not lease.verify():
+            return _result(PublicationState.MANUAL_REVIEW, "publisher_lease_changed", result.transaction_id)
+        return result
     except (OSError, ValueError, ContractViolation, TimeoutError, observer._ObservationFailure) as error:
         return _result(PublicationState.MANUAL_REVIEW, type(error).__name__.lower())
-    finally:
-        if lock is not None:
-            lock.close()
-        for descriptor in (git_fd, steward_fd, root_fd):
-            if descriptor is not None:
-                try:
-                    os.close(descriptor)
-                except OSError:
-                    pass

--- a/steward/context_publication.py
+++ b/steward/context_publication.py
@@ -15,12 +15,13 @@ import os
 import re
 import secrets
 import stat
+import sys
 import threading
 import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Mapping, Protocol, runtime_checkable
+from typing import Mapping
 
 import steward.context_publisher as observer
 from steward.context_contract import ConstitutionAttestation, ContractViolation
@@ -80,19 +81,85 @@ _OPEN_FILE = observer._OPEN_FILE
 _THREAD_LOCK_GUARD = threading.Lock()
 _THREAD_LOCKS: dict[tuple[int, int], threading.Lock] = {}
 _LEASE_TOKEN = object()
+_ISOLATION_TOKEN = object()
 
 
-@runtime_checkable
-class PublisherIsolation(Protocol):
-    """Externally attested process/worktree capability consumed by the publisher."""
+class PublisherIsolation:
+    """Opaque process/worktree attestation issued by the isolated bootstrap."""
 
-    repository_root: Path
-    root_fd: int
-    git_fd: int
-    steward_fd: int
+    __slots__ = (
+        "repository_root",
+        "root_fd",
+        "git_fd",
+        "steward_fd",
+        "_pid",
+        "_root_anchor",
+        "_git_anchor",
+        "_steward_anchor",
+        "_closed",
+    )
+
+    def __init__(
+        self,
+        token: object,
+        repository_root: Path,
+        root_fd: int,
+        git_fd: int,
+        steward_fd: int,
+    ) -> None:
+        if token is not _ISOLATION_TOKEN:
+            raise TypeError("isolation_constructor_private")
+        if not isinstance(repository_root, Path) or not repository_root.is_absolute():
+            raise ValueError("repository_path_invalid")
+        self.repository_root = repository_root
+        self.root_fd = root_fd
+        self.git_fd = git_fd
+        self.steward_fd = steward_fd
+        self._pid = os.getpid()
+        self._root_anchor = _directory_anchor(root_fd)
+        self._git_anchor = _directory_anchor(git_fd)
+        self._steward_anchor = _directory_anchor(steward_fd)
+        self._closed = False
+
+    @classmethod
+    def _from_bootstrap(
+        cls,
+        token: object,
+        repository_root: Path,
+        root_fd: int,
+        git_fd: int,
+        steward_fd: int,
+    ) -> "PublisherIsolation":
+        return cls(token, repository_root, root_fd, git_fd, steward_fd)
 
     def verify(self) -> bool:
-        """Return true only while the dedicated process/worktree remains pinned."""
+        if self._closed or os.getpid() != self._pid:
+            return False
+        fresh_root: int | None = None
+        try:
+            if _directory_anchor(self.root_fd) != self._root_anchor:
+                return False
+            if _directory_anchor(self.git_fd) != self._git_anchor:
+                return False
+            if _directory_anchor(self.steward_fd) != self._steward_anchor:
+                return False
+            fresh_root = observer._open_repository_root(self.repository_root)
+            return _directory_anchor(fresh_root) == self._root_anchor
+        except (OSError, ValueError, observer._ObservationFailure):
+            return False
+        finally:
+            if fresh_root is not None:
+                os.close(fresh_root)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for descriptor in (self.git_fd, self.steward_fd, self.root_fd):
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
 
 
 class PublicationMode(str, Enum):
@@ -1596,6 +1663,8 @@ def publish_context(
         return _result(PublicationState.BLOCKED, "disabled")
     if selected_mode is PublicationMode.PREVIEW:
         return _result(PublicationState.BLOCKED, "preview_only")
+    if selected_mode is PublicationMode.CANONICAL and sys.platform == "darwin":
+        return _result(PublicationState.MANUAL_REVIEW, "unsupported_platform")
     if not isinstance(repository_root, Path) or not repository_root.is_absolute():
         return _result(PublicationState.BLOCKED, "repository_path_invalid")
     if not isinstance(lease, PublisherLease):

--- a/steward/context_publication.py
+++ b/steward/context_publication.py
@@ -119,6 +119,10 @@ class PublisherIsolation:
         self._root_anchor = _directory_anchor(root_fd)
         self._git_anchor = _directory_anchor(git_fd)
         self._steward_anchor = _directory_anchor(steward_fd)
+        if not _directory_child_matches(root_fd, ".git", self._git_anchor):
+            raise ValueError("isolation_repository_binding")
+        if not _directory_child_matches(root_fd, ".steward", self._steward_anchor):
+            raise ValueError("isolation_repository_binding")
         self._closed = False
 
     @classmethod
@@ -464,6 +468,18 @@ def _open_steward(root_fd: int) -> int:
 
 def _open_git(root_fd: int) -> int:
     return os.open(".git", _OPEN_DIRECTORY, dir_fd=root_fd)
+
+
+def _directory_child_matches(root_fd: int, name: str, expected: tuple[int, int, int, int]) -> bool:
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(name, _OPEN_DIRECTORY, dir_fd=root_fd)
+        return _directory_anchor(descriptor) == expected
+    except (OSError, ValueError):
+        return False
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
 
 
 def _parent_fd(root_fd: int, steward_fd: int, path: str) -> tuple[int, str]:

--- a/steward/context_publication.py
+++ b/steward/context_publication.py
@@ -1,0 +1,1119 @@
+"""Isolated, default-disabled D2b Context Bridge transaction primitive.
+
+This module is deliberately uncalled.  It owns the local lock, journal, tempfile,
+replace, read-back, and crash-recovery mechanics, while the existing read-only observer
+and renderer remain the only sources for Git and generation semantics.
+"""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import hashlib
+import json
+import os
+import re
+import secrets
+import stat
+import threading
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Mapping
+
+import steward.context_publisher as observer
+from steward.context_contract import ConstitutionAttestation, ContractViolation
+from steward.context_rendering import (
+    PERSISTED_TARGET_MAX_BYTES,
+    PublicationCandidates,
+    build_publication_candidates,
+    validate_constitution_bound_persisted_generation,
+)
+
+_TARGETS = (
+    "CLAUDE.md",
+    "AGENTS.md",
+    ".steward/context-snapshot.json",
+    ".steward/context-publication.json",
+)
+_ROOT_TARGETS = frozenset(_TARGETS[:2])
+_SCHEMA = "steward.context.transaction/v1"
+_TXID = re.compile(r"^[0-9a-f]{32}$")
+_HEX40 = re.compile(r"^[0-9a-f]{40}$")
+_HEX64 = re.compile(r"^[0-9a-f]{64}$")
+_SNAPSHOT_ID = re.compile(r"^ctxsnap-v1:[0-9a-f]{64}$")
+_LOCK = observer._LOCK
+_REPLACE_ORDER = list(_TARGETS)
+_JOURNAL_MAX_BYTES = 65_536
+_DEADLINE_SECONDS = 20.0
+_LOCK_TIMEOUT_SECONDS = 5.0
+_IDENTITY_KEYS = ("device", "inode", "type", "link_count", "mode")
+_TARGET_IDENTITY_KEYS = (*_IDENTITY_KEYS, "size")
+_TEMP_IDENTITY_KEYS = (*_TARGET_IDENTITY_KEYS, "candidate_sha256")
+_TOP_LEVEL_KEYS = (
+    "schema",
+    "txid",
+    "journal",
+    "repository",
+    "reviewed_head",
+    "replace_order",
+    "targets",
+    "temps",
+    "snapshot_id",
+    "payload_hash",
+    "c0_sha256",
+    "source_blob",
+    "status",
+    "cursor",
+    "completed_targets",
+    "in_flight_target",
+    "installed_targets",
+)
+_TARGET_RECORD_KEYS = ("parent", "baseline", "candidate", "installed")
+_BASELINE_KEYS = ("parent", "target", "present", "mode", "blob", "sha256", "size")
+_CANDIDATE_KEYS = ("sha256", "size")
+_STATUS_VALUES = {"prepared", "replacing", "replaced", "read_back_validated"}
+_OPEN_DIRECTORY = observer._OPEN_DIRECTORY
+_OPEN_FILE = observer._OPEN_FILE
+
+_THREAD_LOCK_GUARD = threading.Lock()
+_THREAD_LOCKS: dict[tuple[int, int], threading.Lock] = {}
+
+
+class PublicationMode(str, Enum):
+    DISABLED = "disabled"
+    PREVIEW = "preview"
+    CANONICAL = "canonical"
+
+
+class PublicationState(str, Enum):
+    PUBLISHED = "published"
+    NO_OP = "no_op"
+    BLOCKED = "blocked"
+    MANUAL_REVIEW = "manual_review"
+
+
+@dataclass(frozen=True)
+class PublicationResult:
+    state: PublicationState
+    reason: str
+    transaction_id: str | None = None
+
+
+@dataclass(frozen=True)
+class _FileState:
+    data: bytes
+    identity: Mapping[str, int | str]
+    stat_key: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _View:
+    head: str
+    tree: Mapping[str, observer._GitTarget]
+    index: Mapping[str, observer._GitTarget]
+    head_blobs: Mapping[str, bytes]
+    worktree: Mapping[str, observer._WorktreeTarget | None]
+    layout: tuple[tuple[int, ...], ...]
+    parents: tuple[tuple[int, ...], ...]
+    state: observer.GenerationState
+    reason: str
+
+
+@dataclass
+class _HeldLock:
+    descriptor: int
+    identity: Mapping[str, int | str]
+    thread_lock: threading.Lock
+    key: tuple[int, int]
+
+    def close(self) -> None:
+        try:
+            fcntl.flock(self.descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(self.descriptor)
+            self.thread_lock.release()
+
+
+def _result(state: PublicationState, reason: str, txid: str | None = None) -> PublicationResult:
+    return PublicationResult(state, reason[:160], txid)
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _stat_key(value: os.stat_result) -> tuple[int, ...]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        stat.S_IFMT(value.st_mode),
+        value.st_nlink,
+        value.st_uid,
+        stat.S_IMODE(value.st_mode),
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _identity(value: os.stat_result, *, include_size: bool = False) -> dict[str, int | str]:
+    result: dict[str, int | str] = {
+        "device": int(value.st_dev),
+        "inode": int(value.st_ino),
+        "type": "regular" if stat.S_ISREG(value.st_mode) else "directory" if stat.S_ISDIR(value.st_mode) else "other",
+        "link_count": int(value.st_nlink),
+        "mode": int(stat.S_IMODE(value.st_mode)),
+    }
+    if include_size:
+        result["size"] = int(value.st_size)
+    return result
+
+
+def _same_identity(expected: Mapping[str, object], actual: Mapping[str, object]) -> bool:
+    return dict(expected) == dict(actual)
+
+
+_STAT_IDENTITY_KEYS = frozenset({"device", "inode", "type", "link_count", "mode", "size"})
+
+
+def _same_stat_identity(expected: Mapping[str, object], actual: Mapping[str, object]) -> bool:
+    expected_identity = {key: expected.get(key) for key in _STAT_IDENTITY_KEYS if key in expected}
+    actual_identity = {key: actual.get(key) for key in _STAT_IDENTITY_KEYS if key in actual}
+    return expected_identity == actual_identity
+
+
+def _is_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _validate_identity(
+    value: object,
+    *,
+    keys: tuple[str, ...],
+    kind: str,
+    mode: int | None = None,
+    size_limit: int | None = None,
+) -> None:
+    if not isinstance(value, Mapping) or tuple(value) != keys:
+        raise ValueError("journal_identity_schema")
+    for key in ("device", "inode", "link_count", "mode"):
+        member = value[key]
+        if not _is_int(member) or member < 0:
+            raise ValueError("journal_identity_value")
+    if value["type"] != kind or (kind == "regular" and value["link_count"] != 1):
+        raise ValueError("journal_identity_type")
+    if mode is not None and value["mode"] != mode:
+        raise ValueError("journal_identity_mode")
+    if "size" in keys:
+        size = value["size"]
+        if not _is_int(size) or size < 0 or (size_limit is not None and size > size_limit):
+            raise ValueError("journal_identity_size")
+    if "candidate_sha256" in keys and (
+        not isinstance(value["candidate_sha256"], str) or not _HEX64.fullmatch(value["candidate_sha256"])
+    ):
+        raise ValueError("journal_candidate_hash")
+
+
+def _validate_candidate_descriptor(value: object, path: str) -> None:
+    if not isinstance(value, Mapping) or tuple(value) != _CANDIDATE_KEYS:
+        raise ValueError("journal_candidate_schema")
+    digest = value["sha256"]
+    if not isinstance(digest, str) or not _HEX64.fullmatch(digest):
+        raise ValueError("journal_candidate_hash")
+    size = value["size"]
+    if not _is_int(size) or size < 0 or size > PERSISTED_TARGET_MAX_BYTES[path]:
+        raise ValueError("journal_candidate_size")
+
+
+def _write_all(descriptor: int, value: bytes) -> None:
+    offset = 0
+    while offset < len(value):
+        try:
+            count = os.write(descriptor, value[offset:])
+        except InterruptedError:
+            continue
+        if count <= 0:
+            raise OSError(errno.EIO, "short write")
+        offset += count
+
+
+def _read_descriptor(descriptor: int, limit: int) -> bytes:
+    chunks = bytearray()
+    while len(chunks) <= limit:
+        try:
+            chunk = os.read(descriptor, min(8192, limit + 1 - len(chunks)))
+        except InterruptedError:
+            continue
+        if not chunk:
+            break
+        chunks.extend(chunk)
+    if len(chunks) > limit:
+        raise ValueError("size_limit")
+    return bytes(chunks)
+
+
+def _require_owned_file(parent_fd: int, name: str) -> None:
+    try:
+        value = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError as error:
+        raise ValueError("transaction_file_missing") from error
+    if value.st_uid != os.geteuid():
+        raise ValueError("transaction_file_owner")
+
+
+def _open_steward(root_fd: int) -> int:
+    return os.open(".steward", _OPEN_DIRECTORY, dir_fd=root_fd)
+
+
+def _open_git(root_fd: int) -> int:
+    return os.open(".git", _OPEN_DIRECTORY, dir_fd=root_fd)
+
+
+def _parent_fd(root_fd: int, steward_fd: int, path: str) -> tuple[int, str]:
+    if path in _ROOT_TARGETS:
+        return root_fd, path
+    return steward_fd, path.removeprefix(".steward/")
+
+
+def _safe_file_state(parent_fd: int, name: str, limit: int) -> _FileState | None:
+    try:
+        listed = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return None
+    if not stat.S_ISREG(listed.st_mode) or listed.st_nlink != 1 or listed.st_size > limit:
+        raise ValueError("unsafe_target")
+    descriptor = os.open(name, _OPEN_FILE, dir_fd=parent_fd)
+    try:
+        before = os.fstat(descriptor)
+        if _stat_key(before) != _stat_key(listed):
+            raise ValueError("target_race")
+        data = _read_descriptor(descriptor, limit)
+        if len(data) != before.st_size:
+            raise ValueError("short_read")
+        after = os.fstat(descriptor)
+        final = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+        if _stat_key(after) != _stat_key(before) or _stat_key(final) != _stat_key(before):
+            raise ValueError("target_race")
+        return _FileState(data, _identity(before, include_size=True), _stat_key(before))
+    finally:
+        os.close(descriptor)
+
+
+def _parent_identity(descriptor: int) -> dict[str, int | str]:
+    value = os.fstat(descriptor)
+    if not stat.S_ISDIR(value.st_mode) or value.st_nlink < 1 or value.st_uid != os.geteuid() or value.st_mode & 0o022:
+        raise ValueError("unsafe_parent")
+    return _identity(value)
+
+
+def _open_thread_lock(key: tuple[int, int]) -> threading.Lock:
+    with _THREAD_LOCK_GUARD:
+        lock = _THREAD_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _THREAD_LOCKS[key] = lock
+        return lock
+
+
+def _acquire_lock(steward_fd: int, deadline: float) -> _HeldLock:
+    descriptor = os.open(
+        _LOCK,
+        os.O_RDWR | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW,
+        0o600,
+        dir_fd=steward_fd,
+    )
+    value = os.fstat(descriptor)
+    identity = _identity(value)
+    if (
+        identity["type"] != "regular"
+        or identity["link_count"] != 1
+        or identity["mode"] != 0o600
+        or value.st_uid != os.geteuid()
+    ):
+        os.close(descriptor)
+        raise ValueError("unsafe_lock")
+    key = (int(value.st_dev), int(value.st_ino))
+    thread_lock = _open_thread_lock(key)
+    remaining = min(_LOCK_TIMEOUT_SECONDS, deadline - time.monotonic())
+    if remaining <= 0 or not thread_lock.acquire(timeout=remaining):
+        os.close(descriptor)
+        raise TimeoutError("thread_lock_timeout")
+    try:
+        while True:
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("flock_timeout")
+                time.sleep(min(0.02, max(0.001, deadline - time.monotonic())))
+        if _identity(os.fstat(descriptor)) != identity:
+            raise ValueError("lock_replaced")
+        return _HeldLock(descriptor, identity, thread_lock, key)
+    except Exception:
+        thread_lock.release()
+        os.close(descriptor)
+        raise
+
+
+def _scan_namespace(root_fd: int, steward_fd: int) -> tuple[list[str], list[str], bool]:
+    journals: list[str] = []
+    temps: list[str] = []
+    unknown = False
+    for name in os.listdir(root_fd):
+        if observer._ROOT_TEMP.fullmatch(name):
+            temps.append(name)
+        elif name.startswith(".context-publish-"):
+            unknown = True
+    for name in os.listdir(steward_fd):
+        if name == _LOCK:
+            continue
+        if observer._TRANSACTION.fullmatch(name):
+            journals.append(name)
+        elif observer._STEWARD_TEMP.fullmatch(name):
+            temps.append(name)
+        elif name.startswith(".context-publish-"):
+            unknown = True
+    return journals, temps, unknown
+
+
+def _view(
+    root_fd: int,
+    git_fd: int,
+    steward_fd: int,
+    attestation: ConstitutionAttestation,
+    git: str,
+    deadline: float,
+) -> _View:
+    layout = observer._git_layout_fingerprint(root_fd, git_fd)
+    head, tree, index, head_blobs = observer._read_git_evidence(git, git_fd, deadline)
+    worktree = observer._read_worktree(root_fd, steward_fd)
+    parents = observer._target_parent_fingerprint(root_fd, steward_fd)
+    evidence = observer._RepositoryEvidence(
+        head=head,
+        tree=tree,
+        index=index,
+        head_blobs=head_blobs,
+        worktree=worktree,
+        publisher_signal=False,
+        multiple_or_unknown_signal=False,
+    )
+    state, reason, _ = observer._classify(evidence, attestation)
+    if observer._git_layout_fingerprint(root_fd, git_fd) != layout:
+        raise ValueError("git_layout_changed")
+    return _View(head, tree, index, head_blobs, worktree, layout, parents, state, reason)
+
+
+def _same_view(left: _View, right: _View) -> bool:
+    return (
+        left.head == right.head
+        and left.tree == right.tree
+        and left.index == right.index
+        and left.head_blobs == right.head_blobs
+        and left.worktree == right.worktree
+        and left.layout == right.layout
+        and left.parents == right.parents
+    )
+
+
+def _candidate_metadata(candidates: PublicationCandidates) -> tuple[str, str, str]:
+    snapshot = json.loads(candidates.snapshot_artifact.decode("utf-8"))
+    publication = json.loads(candidates.publication_artifact.decode("utf-8"))
+    snapshot_id = snapshot["snapshot_id"]
+    payload_hash = publication["previous"]["payload_hash"]
+    if not _SNAPSHOT_ID.fullmatch(snapshot_id) or not _HEX64.fullmatch(payload_hash):
+        raise ValueError("candidate_metadata")
+    return snapshot_id, payload_hash, hashlib.sha256(candidates.claude_md).hexdigest()
+
+
+def _target_baseline(
+    path: str,
+    parent_fd: int,
+    parent_identity: Mapping[str, int | str],
+    view: _View,
+) -> dict[str, object]:
+    current = _safe_file_state(parent_fd, path.removeprefix(".steward/"), PERSISTED_TARGET_MAX_BYTES[path])
+    tree_target = view.tree.get(path)
+    head_bytes = view.head_blobs.get(path)
+    if current is None:
+        if tree_target is not None or path in view.index:
+            raise ValueError("worktree_git_mismatch")
+        return {
+            "parent": dict(parent_identity),
+            "target": None,
+            "present": False,
+            "mode": None,
+            "blob": None,
+            "sha256": None,
+            "size": None,
+        }
+    if tree_target is None or head_bytes is None or current.data != head_bytes:
+        raise ValueError("baseline_unbound")
+    return {
+        "parent": dict(parent_identity),
+        "target": dict(current.identity),
+        "present": True,
+        "mode": int(current.identity["mode"]),
+        "blob": tree_target.blob,
+        "sha256": hashlib.sha256(current.data).hexdigest(),
+        "size": len(current.data),
+    }
+
+
+def _journal_template(
+    txid: str,
+    journal_identity: Mapping[str, int | str],
+    root_fd: int,
+    git_fd: int,
+    steward_fd: int,
+    view: _View,
+    candidates: PublicationCandidates,
+    attestation: ConstitutionAttestation,
+) -> dict[str, object]:
+    snapshot_id, payload_hash, _ = _candidate_metadata(candidates)
+    root_identity = _parent_identity(root_fd)
+    git_identity = _parent_identity(git_fd)
+    steward_identity = _parent_identity(steward_fd)
+    targets: dict[str, object] = {}
+    for path in _TARGETS:
+        parent_fd, name = _parent_fd(root_fd, steward_fd, path)
+        parent_identity = _parent_identity(parent_fd)
+        baseline = _target_baseline(path, parent_fd, parent_identity, view)
+        data = getattr(
+            candidates,
+            {
+                "CLAUDE.md": "claude_md",
+                "AGENTS.md": "agents_md",
+                ".steward/context-snapshot.json": "snapshot_artifact",
+                ".steward/context-publication.json": "publication_artifact",
+            }[path],
+        )
+        targets[path] = {
+            "parent": dict(parent_identity),
+            "baseline": baseline,
+            "candidate": {"sha256": hashlib.sha256(data).hexdigest(), "size": len(data)},
+            "installed": None,
+        }
+    return {
+        "schema": _SCHEMA,
+        "txid": txid,
+        "journal": dict(journal_identity),
+        "repository": {"root": root_identity, "git": git_identity, "steward": steward_identity},
+        "reviewed_head": view.head,
+        "replace_order": list(_REPLACE_ORDER),
+        "targets": targets,
+        "temps": {path: None for path in _TARGETS},
+        "snapshot_id": snapshot_id,
+        "payload_hash": payload_hash,
+        "c0_sha256": attestation.c0_sha256,
+        "source_blob": attestation.source_blob,
+        "status": "prepared",
+        "cursor": 0,
+        "completed_targets": [],
+        "in_flight_target": None,
+        "installed_targets": {},
+    }
+
+
+def _write_journal(descriptor: int, steward_fd: int, journal: Mapping[str, object]) -> None:
+    txid = journal.get("txid")
+    if not isinstance(txid, str):
+        raise ValueError("journal_txid")
+    _validate_journal_schema(dict(journal), f".context-publish-v1.{txid}.txn")
+    value = _canonical_json(journal)
+    if len(value) > _JOURNAL_MAX_BYTES:
+        raise ValueError("journal_size")
+    expected = journal["journal"]
+    if not isinstance(expected, Mapping) or not _same_identity(expected, _identity(os.fstat(descriptor))):
+        raise ValueError("journal_replaced")
+    os.ftruncate(descriptor, 0)
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    _write_all(descriptor, value)
+    os.fsync(descriptor)
+    os.fsync(steward_fd)
+
+
+def _validate_journal_schema(parsed: object, journal_name: str) -> dict[str, object]:
+    if not isinstance(parsed, dict) or tuple(parsed) != _TOP_LEVEL_KEYS:
+        raise ValueError("journal_schema")
+    if parsed["schema"] != _SCHEMA:
+        raise ValueError("journal_schema")
+    txid = parsed["txid"]
+    if not isinstance(txid, str) or not _TXID.fullmatch(txid):
+        raise ValueError("journal_txid")
+    if journal_name != f".context-publish-v1.{txid}.txn":
+        raise ValueError("journal_name")
+
+    _validate_identity(parsed["journal"], keys=_IDENTITY_KEYS, kind="regular", mode=0o600)
+    repository = parsed["repository"]
+    if not isinstance(repository, Mapping) or tuple(repository) != ("root", "git", "steward"):
+        raise ValueError("journal_repository")
+    for value in repository.values():
+        _validate_identity(value, keys=_IDENTITY_KEYS, kind="directory")
+
+    reviewed_head = parsed["reviewed_head"]
+    if not isinstance(reviewed_head, str) or not _HEX40.fullmatch(reviewed_head):
+        raise ValueError("journal_head")
+    if parsed["replace_order"] != list(_REPLACE_ORDER):
+        raise ValueError("journal_order")
+    for field in ("source_blob",):
+        value = parsed[field]
+        if not isinstance(value, str) or not _HEX40.fullmatch(value):
+            raise ValueError("journal_attestation")
+    for field in ("c0_sha256", "payload_hash"):
+        value = parsed[field]
+        if not isinstance(value, str) or not _HEX64.fullmatch(value):
+            raise ValueError("journal_attestation")
+    snapshot_id = parsed["snapshot_id"]
+    if not isinstance(snapshot_id, str) or not _SNAPSHOT_ID.fullmatch(snapshot_id):
+        raise ValueError("journal_snapshot")
+
+    targets = parsed["targets"]
+    temps = parsed["temps"]
+    if not isinstance(targets, Mapping) or tuple(targets) != _TARGETS:
+        raise ValueError("journal_targets")
+    if not isinstance(temps, Mapping) or tuple(temps) != _TARGETS:
+        raise ValueError("journal_temps")
+    for path in _TARGETS:
+        record = targets[path]
+        if not isinstance(record, Mapping) or tuple(record) != _TARGET_RECORD_KEYS:
+            raise ValueError("journal_target_record")
+        parent = record["parent"]
+        _validate_identity(parent, keys=_IDENTITY_KEYS, kind="directory")
+        baseline = record["baseline"]
+        if not isinstance(baseline, Mapping) or tuple(baseline) != _BASELINE_KEYS:
+            raise ValueError("journal_baseline")
+        _validate_identity(baseline["parent"], keys=_IDENTITY_KEYS, kind="directory")
+        if baseline["parent"] != parent:
+            raise ValueError("journal_baseline_parent")
+        present = baseline["present"]
+        if not isinstance(present, bool):
+            raise ValueError("journal_baseline_present")
+        if present:
+            _validate_identity(
+                baseline["target"],
+                keys=_TARGET_IDENTITY_KEYS,
+                kind="regular",
+                size_limit=PERSISTED_TARGET_MAX_BYTES[path],
+            )
+            if baseline["mode"] != baseline["target"]["mode"]:
+                raise ValueError("journal_baseline_mode")
+            if not isinstance(baseline["blob"], str) or not _HEX40.fullmatch(baseline["blob"]):
+                raise ValueError("journal_baseline_blob")
+            if not isinstance(baseline["sha256"], str) or not _HEX64.fullmatch(baseline["sha256"]):
+                raise ValueError("journal_baseline_hash")
+            if not _is_int(baseline["size"]) or baseline["size"] != baseline["target"]["size"]:
+                raise ValueError("journal_baseline_size")
+        elif any(baseline[field] is not None for field in ("target", "mode", "blob", "sha256", "size")):
+            raise ValueError("journal_absent_baseline")
+        _validate_candidate_descriptor(record["candidate"], path)
+        installed = record["installed"]
+        if installed is not None:
+            _validate_identity(
+                installed,
+                keys=_TEMP_IDENTITY_KEYS,
+                kind="regular",
+                mode=0o644,
+                size_limit=PERSISTED_TARGET_MAX_BYTES[path],
+            )
+            if (
+                installed["candidate_sha256"] != record["candidate"]["sha256"]
+                or installed["size"] != record["candidate"]["size"]
+            ):
+                raise ValueError("journal_installed_candidate")
+        temp = temps[path]
+        if temp is not None:
+            _validate_identity(
+                temp,
+                keys=_TEMP_IDENTITY_KEYS,
+                kind="regular",
+                mode=0o600,
+                size_limit=PERSISTED_TARGET_MAX_BYTES[path],
+            )
+            if temp["candidate_sha256"] != record["candidate"]["sha256"] or temp["size"] != record["candidate"]["size"]:
+                raise ValueError("journal_temp_candidate")
+
+    status = parsed["status"]
+    cursor = parsed["cursor"]
+    if status not in _STATUS_VALUES or not _is_int(cursor) or not 0 <= cursor <= len(_TARGETS):
+        raise ValueError("journal_state")
+    completed = parsed["completed_targets"]
+    if completed != list(_TARGETS[:cursor]):
+        raise ValueError("journal_completed")
+    in_flight = parsed["in_flight_target"]
+    if status == "prepared" and (cursor != 0 or in_flight is not None):
+        raise ValueError("journal_prepared_state")
+    if status == "replacing" and (cursor not in (1, 2, 3) or in_flight != _TARGETS[cursor]):
+        raise ValueError("journal_replacing_state")
+    if status in {"replaced", "read_back_validated"} and (cursor != 4 or in_flight is not None):
+        raise ValueError("journal_complete_state")
+    installed_targets = parsed["installed_targets"]
+    if not isinstance(installed_targets, Mapping) or tuple(installed_targets) != _TARGETS[:cursor]:
+        raise ValueError("journal_installed_targets")
+    for path in _TARGETS[:cursor]:
+        if targets[path]["installed"] != installed_targets[path]:
+            raise ValueError("journal_installed_binding")
+    for path in _TARGETS[cursor:]:
+        if targets[path]["installed"] is not None:
+            raise ValueError("journal_installed_suffix")
+    return parsed
+
+
+def _open_journal(steward_fd: int, name: str) -> tuple[int, dict[str, object]]:
+    _require_owned_file(steward_fd, name)
+    descriptor = os.open(name, _OPEN_FILE, dir_fd=steward_fd)
+    try:
+        identity = _identity(os.fstat(descriptor))
+        if os.fstat(descriptor).st_uid != os.geteuid():
+            raise ValueError("journal_owner")
+        raw = _read_descriptor(descriptor, _JOURNAL_MAX_BYTES)
+    except Exception:
+        os.close(descriptor)
+        raise
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+        if _canonical_json(parsed) != raw or not isinstance(parsed, dict):
+            raise ValueError("journal_encoding")
+        parsed = _validate_journal_schema(parsed, name)
+        if not _same_identity(parsed["journal"], identity):
+            raise ValueError("journal_identity")
+        return descriptor, parsed
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _temp_name(path: str, txid: str) -> tuple[int, str]:
+    if path == "CLAUDE.md":
+        return 0, f".context-publish-v1.{txid}.claude.tmp"
+    if path == "AGENTS.md":
+        return 0, f".context-publish-v1.{txid}.agents.tmp"
+    if path.endswith("context-snapshot.json"):
+        return 1, f".context-publish-v1.{txid}.snapshot.tmp"
+    return 1, f".context-publish-v1.{txid}.publication.tmp"
+
+
+def _candidate_bytes(candidates: PublicationCandidates, path: str) -> bytes:
+    return {
+        "CLAUDE.md": candidates.claude_md,
+        "AGENTS.md": candidates.agents_md,
+        ".steward/context-snapshot.json": candidates.snapshot_artifact,
+        ".steward/context-publication.json": candidates.publication_artifact,
+    }[path]
+
+
+def _prepare_temp(
+    root_fd: int,
+    steward_fd: int,
+    journal_fd: int,
+    journal: dict[str, object],
+    path: str,
+    data: bytes,
+) -> None:
+    parent_kind, name = _temp_name(path, journal["txid"])
+    parent_fd = root_fd if parent_kind == 0 else steward_fd
+    descriptor = os.open(
+        name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+        0o600,
+        dir_fd=parent_fd,
+    )
+    try:
+        _write_all(descriptor, data)
+        os.fsync(descriptor)
+        value = os.fstat(descriptor)
+        if not stat.S_ISREG(value.st_mode) or value.st_nlink != 1 or stat.S_IMODE(value.st_mode) != 0o600:
+            raise ValueError("unsafe_temp")
+        temp_identity = _identity(value, include_size=True)
+    finally:
+        os.close(descriptor)
+    check = _safe_file_state(parent_fd, name, PERSISTED_TARGET_MAX_BYTES[path])
+    if check is None or check.data != data or check.identity != temp_identity:
+        raise ValueError("temp_changed")
+    journal["temps"][path] = {**temp_identity, "candidate_sha256": hashlib.sha256(data).hexdigest()}
+    current_parent = _parent_identity(parent_fd)
+    for target_path in _TARGETS:
+        target_parent_fd, _ = _parent_fd(root_fd, steward_fd, target_path)
+        if target_parent_fd == parent_fd:
+            journal["targets"][target_path]["parent"] = dict(current_parent)
+            journal["targets"][target_path]["baseline"]["parent"] = dict(current_parent)
+    journal["repository"]["root"] = _parent_identity(root_fd)
+    journal["repository"]["steward"] = _parent_identity(steward_fd)
+    _write_journal(journal_fd, steward_fd, journal)
+
+
+def _fence_parent(root_fd: int, steward_fd: int, path: str, expected: Mapping[str, object]) -> int:
+    parent_fd, _ = _parent_fd(root_fd, steward_fd, path)
+    if not _same_identity(expected, _parent_identity(parent_fd)):
+        raise ValueError("parent_changed")
+    return parent_fd
+
+
+def _fence_targets(
+    root_fd: int,
+    steward_fd: int,
+    journal: Mapping[str, object],
+    candidates: PublicationCandidates,
+    cursor: int,
+) -> None:
+    targets = journal["targets"]
+    for index, path in enumerate(_TARGETS):
+        record = targets[path]
+        parent_fd = _fence_parent(root_fd, steward_fd, path, record["parent"])
+        baseline = record["baseline"]
+        if index < cursor:
+            expected = record["installed"]
+            expected_data = _candidate_bytes(candidates, path)
+        else:
+            expected = baseline["target"]
+            expected_data = None
+        state = _safe_file_state(parent_fd, path.removeprefix(".steward/"), PERSISTED_TARGET_MAX_BYTES[path])
+        if index < cursor:
+            if state is None or not _same_stat_identity(expected, state.identity) or state.data != expected_data:
+                raise ValueError("target_changed")
+        elif baseline["present"]:
+            if (
+                state is None
+                or not _same_stat_identity(expected, state.identity)
+                or hashlib.sha256(state.data).hexdigest() != baseline["sha256"]
+            ):
+                raise ValueError("baseline_changed")
+        elif state is not None:
+            raise ValueError("unexpected_target")
+
+
+def _replace_one(
+    root_fd: int,
+    steward_fd: int,
+    journal_fd: int,
+    journal: dict[str, object],
+    candidates: PublicationCandidates,
+    index: int,
+) -> None:
+    path = _TARGETS[index]
+    txid = journal["txid"]
+    parent_kind, temp_name = _temp_name(path, txid)
+    parent_fd = root_fd if parent_kind == 0 else steward_fd
+    record = journal["targets"][path]
+    _fence_targets(root_fd, steward_fd, journal, candidates, index)
+    _fence_parent(root_fd, steward_fd, path, record["parent"])
+    temp = _safe_file_state(parent_fd, temp_name, PERSISTED_TARGET_MAX_BYTES[path])
+    expected_temp = journal["temps"][path]
+    if (
+        temp is None
+        or expected_temp is None
+        or not _same_stat_identity(expected_temp, temp.identity)
+        or temp.data != _candidate_bytes(candidates, path)
+    ):
+        raise ValueError("temp_changed")
+    _fence_parent(root_fd, steward_fd, path, record["parent"])
+    target_name = path.removeprefix(".steward/")
+    os.replace(temp_name, target_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+    descriptor = os.open(target_name, _OPEN_FILE, dir_fd=parent_fd)
+    try:
+        os.fchmod(descriptor, 0o644)
+        os.fsync(descriptor)
+        installed = _safe_file_state(parent_fd, target_name, PERSISTED_TARGET_MAX_BYTES[path])
+    finally:
+        os.close(descriptor)
+    if installed is None or installed.data != _candidate_bytes(candidates, path):
+        raise ValueError("readback_failed")
+    record["installed"] = {**installed.identity, "candidate_sha256": hashlib.sha256(installed.data).hexdigest()}
+    journal["installed_targets"][path] = record["installed"]
+    journal["cursor"] = index + 1
+    journal["completed_targets"] = list(_TARGETS[: index + 1])
+    if index + 1 < len(_TARGETS):
+        journal["status"] = "replacing"
+        journal["in_flight_target"] = _TARGETS[index + 1]
+    else:
+        journal["status"] = "replaced"
+        journal["in_flight_target"] = None
+    _write_journal(journal_fd, steward_fd, journal)
+    os.fsync(parent_fd)
+
+
+def _cleanup_transaction(root_fd: int, steward_fd: int, journal_fd: int, journal: Mapping[str, object]) -> None:
+    _validate_transaction_namespace(root_fd, steward_fd, journal)
+    txid = journal["txid"]
+    parent_fences: dict[int, dict[str, int | str]] = {}
+    for path in _TARGETS:
+        parent_kind, name = _temp_name(path, txid)
+        parent_fd = root_fd if parent_kind == 0 else steward_fd
+        expected = journal["temps"][path]
+        if expected is None:
+            continue
+        current_parent = _parent_identity(parent_fd)
+        parent_key = int(parent_fd)
+        if parent_key not in parent_fences:
+            if not _same_identity(current_parent, journal["targets"][path]["parent"]):
+                raise ValueError("parent_changed")
+        elif not _same_identity(current_parent, parent_fences[parent_key]):
+            raise ValueError("parent_changed")
+        state = _safe_file_state(parent_fd, name, PERSISTED_TARGET_MAX_BYTES[path])
+        if state is None and path in journal["installed_targets"]:
+            parent_fences[parent_key] = current_parent
+            continue
+        _require_owned_file(parent_fd, name)
+        if state is None or not _same_stat_identity(expected, state.identity):
+            raise ValueError("temp_cleanup_identity")
+        os.unlink(name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+        parent_fences[parent_key] = _parent_identity(parent_fd)
+    identity = journal["journal"]
+    if not _same_identity(identity, _identity(os.fstat(journal_fd))):
+        raise ValueError("journal_cleanup_identity")
+    if int(steward_fd) not in parent_fences:
+        parent_fences[int(steward_fd)] = _parent_identity(steward_fd)
+    if not _same_identity(_parent_identity(steward_fd), parent_fences[int(steward_fd)]):
+        raise ValueError("repository_parent_changed")
+    os.unlink(f".context-publish-v1.{txid}.txn", dir_fd=steward_fd)
+    os.fsync(steward_fd)
+
+
+def _create_transaction(
+    root_fd: int,
+    git_fd: int,
+    steward_fd: int,
+    view: _View,
+    candidates: PublicationCandidates,
+    attestation: ConstitutionAttestation,
+) -> PublicationResult:
+    txid = secrets.token_hex(16)
+    name = f".context-publish-v1.{txid}.txn"
+    journal_fd = os.open(
+        name,
+        os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+        0o600,
+        dir_fd=steward_fd,
+    )
+    try:
+        journal_identity = _identity(os.fstat(journal_fd))
+        journal = _journal_template(txid, journal_identity, root_fd, git_fd, steward_fd, view, candidates, attestation)
+        _write_journal(journal_fd, steward_fd, journal)
+        for path in _TARGETS:
+            _prepare_temp(root_fd, steward_fd, journal_fd, journal, path, _candidate_bytes(candidates, path))
+        _validate_transaction_namespace(root_fd, steward_fd, journal)
+        for index in range(len(_TARGETS)):
+            _validate_transaction_namespace(root_fd, steward_fd, journal)
+            _fence_targets(root_fd, steward_fd, journal, candidates, index)
+            _replace_one(root_fd, steward_fd, journal_fd, journal, candidates, index)
+        _validate_transaction_namespace(root_fd, steward_fd, journal)
+        _fence_targets(root_fd, steward_fd, journal, candidates, len(_TARGETS))
+        journal["status"] = "read_back_validated"
+        _write_journal(journal_fd, steward_fd, journal)
+        _cleanup_transaction(root_fd, steward_fd, journal_fd, journal)
+        return _result(PublicationState.PUBLISHED, "published", txid)
+    except (OSError, ValueError, ContractViolation, TimeoutError, observer._ObservationFailure) as error:
+        return _result(PublicationState.MANUAL_REVIEW, type(error).__name__.lower(), txid)
+    finally:
+        os.close(journal_fd)
+
+
+def _transaction_temp_names(txid: str) -> frozenset[str]:
+    return frozenset(_temp_name(path, txid)[1] for path in _TARGETS)
+
+
+def _validate_transaction_namespace(root_fd: int, steward_fd: int, journal: Mapping[str, object]) -> None:
+    journal_name = f".context-publish-v1.{journal['txid']}.txn"
+    journals, temps, unknown = _scan_namespace(root_fd, steward_fd)
+    if unknown or journals != [journal_name]:
+        raise ValueError("transaction_namespace_ambiguous")
+    present_temps = set(temps)
+    expected_temps = _transaction_temp_names(journal["txid"])
+    if present_temps - expected_temps:
+        raise ValueError("transaction_namespace_ambiguous")
+    cursor = journal["cursor"]
+    for index, path in enumerate(_TARGETS):
+        name = _temp_name(path, journal["txid"])[1]
+        if index < cursor:
+            if name in present_temps:
+                raise ValueError("installed_temp_present")
+        elif journal["temps"][path] is None:
+            if name in present_temps:
+                raise ValueError("unexpected_temp")
+        elif name not in present_temps:
+            raise ValueError("temp_missing")
+
+
+def _validate_transaction_files(root_fd: int, steward_fd: int, journal: Mapping[str, object]) -> None:
+    txid = journal["txid"]
+    cursor = journal["cursor"]
+    for index, path in enumerate(_TARGETS):
+        parent_kind, name = _temp_name(path, txid)
+        parent_fd = root_fd if parent_kind == 0 else steward_fd
+        expected = journal["temps"][path]
+        state = _safe_file_state(parent_fd, name, PERSISTED_TARGET_MAX_BYTES[path])
+        if index < cursor:
+            if state is not None:
+                raise ValueError("installed_temp_present")
+            continue
+        if expected is None:
+            if state is not None:
+                raise ValueError("unexpected_temp")
+            continue
+        _require_owned_file(parent_fd, name)
+        candidate = journal["targets"][path]["candidate"]
+        if (
+            state is None
+            or not _same_stat_identity(expected, state.identity)
+            or hashlib.sha256(state.data).hexdigest() != candidate["sha256"]
+            or len(state.data) != candidate["size"]
+        ):
+            raise ValueError("temp_foreign")
+
+
+def _validate_journal_binding(
+    root_fd: int,
+    git_fd: int,
+    steward_fd: int,
+    journal: Mapping[str, object],
+    candidates: PublicationCandidates,
+    attestation: ConstitutionAttestation,
+    view: _View,
+) -> None:
+    snapshot_id, payload_hash, _ = _candidate_metadata(candidates)
+    if (
+        journal["reviewed_head"] != view.head
+        or journal["snapshot_id"] != snapshot_id
+        or journal["payload_hash"] != payload_hash
+        or journal["c0_sha256"] != attestation.c0_sha256
+        or journal["source_blob"] != attestation.source_blob
+    ):
+        raise ValueError("journal_binding")
+    if journal["repository"] != {
+        "root": _parent_identity(root_fd),
+        "git": _parent_identity(git_fd),
+        "steward": _parent_identity(steward_fd),
+    }:
+        raise ValueError("repository_binding")
+    for path in _TARGETS:
+        data = _candidate_bytes(candidates, path)
+        descriptor = journal["targets"][path]["candidate"]
+        if descriptor["sha256"] != hashlib.sha256(data).hexdigest() or descriptor["size"] != len(data):
+            raise ValueError("candidate_binding")
+
+
+def _recover_existing(
+    root_fd: int,
+    git_fd: int,
+    steward_fd: int,
+    journal_name: str,
+    attestation: ConstitutionAttestation,
+    candidates: PublicationCandidates,
+    deadline: float,
+) -> PublicationResult:
+    journals, temps, unknown = _scan_namespace(root_fd, steward_fd)
+    if unknown or journals != [journal_name]:
+        return _result(PublicationState.MANUAL_REVIEW, "transaction_namespace_ambiguous")
+    try:
+        journal_fd, journal = _open_journal(steward_fd, journal_name)
+    except (OSError, ValueError, UnicodeError, json.JSONDecodeError):
+        return _result(PublicationState.MANUAL_REVIEW, "journal_invalid")
+    try:
+        _validate_transaction_namespace(root_fd, steward_fd, journal)
+        git, _ = _safe_git()
+        view = _view(root_fd, git_fd, steward_fd, attestation, git, deadline)
+        _validate_journal_binding(root_fd, git_fd, steward_fd, journal, candidates, attestation, view)
+        _validate_transaction_files(root_fd, steward_fd, journal)
+        status = journal.get("status")
+        cursor = journal.get("cursor")
+        if status == "prepared" and cursor == 0:
+            _fence_targets(root_fd, steward_fd, journal, candidates, 0)
+            _cleanup_transaction(root_fd, steward_fd, journal_fd, journal)
+            return _result(PublicationState.BLOCKED, "recovered_prepared", journal["txid"])
+        if status in {"replaced", "read_back_validated"} and cursor == 4:
+            _fence_targets(root_fd, steward_fd, journal, candidates, 4)
+            _cleanup_transaction(root_fd, steward_fd, journal_fd, journal)
+            return _result(PublicationState.PUBLISHED, "recovered_generation", journal["txid"])
+        if status == "replacing" and isinstance(cursor, int) and 1 <= cursor <= 3:
+            _fence_targets(root_fd, steward_fd, journal, candidates, cursor)
+            return _result(PublicationState.MANUAL_REVIEW, "recovery_requires_review", journal["txid"])
+        return _result(PublicationState.MANUAL_REVIEW, "recovery_state_invalid", journal["txid"])
+    except (OSError, ValueError, ContractViolation, TimeoutError, observer._ObservationFailure) as error:
+        return _result(PublicationState.MANUAL_REVIEW, type(error).__name__.lower(), journal.get("txid"))
+    finally:
+        os.close(journal_fd)
+
+
+def _safe_git() -> tuple[str, tuple[int, ...]]:
+    return observer._safe_executable(("/usr/bin/git", "/bin/git"))
+
+
+def publish_context(
+    repository_root: Path,
+    payload: Mapping[str, object],
+    snapshot: Mapping[str, object],
+    attestation: ConstitutionAttestation,
+    *,
+    mode: PublicationMode | str = PublicationMode.DISABLED,
+    isolation_attested: bool = False,
+) -> PublicationResult:
+    """Publish one validated generation; canonical mode is never caller-wired."""
+    try:
+        selected_mode = mode if isinstance(mode, PublicationMode) else PublicationMode(mode)
+    except (TypeError, ValueError):
+        selected_mode = PublicationMode.DISABLED
+    try:
+        candidates = build_publication_candidates(payload, snapshot)
+        validate_constitution_bound_persisted_generation(candidates, attestation)
+    except (ContractViolation, TypeError, ValueError, KeyError, UnicodeError):
+        return _result(PublicationState.BLOCKED, "candidate_invalid")
+    if selected_mode is PublicationMode.DISABLED:
+        return _result(PublicationState.BLOCKED, "disabled")
+    if selected_mode is PublicationMode.PREVIEW:
+        return _result(PublicationState.BLOCKED, "preview_only")
+    if not isolation_attested:
+        return _result(PublicationState.BLOCKED, "isolation_not_attested")
+    if not isinstance(repository_root, Path) or not repository_root.is_absolute():
+        return _result(PublicationState.BLOCKED, "repository_path_invalid")
+    root_fd = git_fd = steward_fd = None
+    lock: _HeldLock | None = None
+    deadline = time.monotonic() + _DEADLINE_SECONDS
+    try:
+        root_fd = observer._open_repository_root(repository_root)
+        steward_fd = _open_steward(root_fd)
+        git_fd = _open_git(root_fd)
+        git, _ = _safe_git()
+        journals, temps, unknown = _scan_namespace(root_fd, steward_fd)
+        lock = _acquire_lock(steward_fd, deadline)
+        if unknown or len(journals) > 1:
+            return _result(PublicationState.MANUAL_REVIEW, "transaction_namespace_ambiguous")
+        if journals or temps:
+            if len(journals) != 1:
+                return _result(PublicationState.MANUAL_REVIEW, "transaction_journal_missing")
+            return _recover_existing(root_fd, git_fd, steward_fd, journals[0], attestation, candidates, deadline)
+        before = _view(root_fd, git_fd, steward_fd, attestation, git, deadline)
+        if before.state not in {observer.GenerationState.ABSENT, observer.GenerationState.VALID}:
+            return _result(PublicationState.MANUAL_REVIEW, f"baseline_{before.state.value}")
+        after = _view(root_fd, git_fd, steward_fd, attestation, git, deadline)
+        if not _same_view(before, after):
+            return _result(PublicationState.MANUAL_REVIEW, "repository_changed_before_transaction")
+        if before.state is observer.GenerationState.VALID:
+            current_states = {}
+            for path in _TARGETS:
+                parent_fd, name = _parent_fd(root_fd, steward_fd, path)
+                current_states[path] = _safe_file_state(parent_fd, name, PERSISTED_TARGET_MAX_BYTES[path])
+            if all(
+                current_states[path] is not None and current_states[path].data == _candidate_bytes(candidates, path)
+                for path in _TARGETS
+            ):
+                return _result(PublicationState.NO_OP, "already_published")
+        return _create_transaction(root_fd, git_fd, steward_fd, after, candidates, attestation)
+    except (OSError, ValueError, ContractViolation, TimeoutError, observer._ObservationFailure) as error:
+        return _result(PublicationState.MANUAL_REVIEW, type(error).__name__.lower())
+    finally:
+        if lock is not None:
+            lock.close()
+        for descriptor in (git_fd, steward_fd, root_fd):
+            if descriptor is not None:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass

--- a/steward/context_publication.py
+++ b/steward/context_publication.py
@@ -20,7 +20,7 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Mapping
+from typing import Mapping, Protocol, runtime_checkable
 
 import steward.context_publisher as observer
 from steward.context_contract import ConstitutionAttestation, ContractViolation
@@ -80,6 +80,19 @@ _OPEN_FILE = observer._OPEN_FILE
 _THREAD_LOCK_GUARD = threading.Lock()
 _THREAD_LOCKS: dict[tuple[int, int], threading.Lock] = {}
 _LEASE_TOKEN = object()
+
+
+@runtime_checkable
+class PublisherIsolation(Protocol):
+    """Externally attested process/worktree capability consumed by the publisher."""
+
+    repository_root: Path
+    root_fd: int
+    git_fd: int
+    steward_fd: int
+
+    def verify(self) -> bool:
+        """Return true only while the dedicated process/worktree remains pinned."""
 
 
 class PublicationMode(str, Enum):
@@ -142,6 +155,7 @@ class PublisherLease:
 
     __slots__ = (
         "_repository_root",
+        "_isolation",
         "_root_fd",
         "_git_fd",
         "_steward_fd",
@@ -158,7 +172,7 @@ class PublisherLease:
     def __init__(
         self,
         token: object,
-        repository_root: Path,
+        isolation: PublisherIsolation,
         root_fd: int,
         git_fd: int,
         steward_fd: int,
@@ -169,7 +183,8 @@ class PublisherLease:
         if token is not _LEASE_TOKEN:
             raise TypeError("lease_constructor_private")
         self._token = token
-        self._repository_root = repository_root
+        self._isolation = isolation
+        self._repository_root = isolation.repository_root
         self._root_fd = root_fd
         self._git_fd = git_fd
         self._steward_fd = steward_fd
@@ -203,15 +218,25 @@ class PublisherLease:
         if self._closed or os.getpid() != self._pid or time.monotonic() >= self._deadline:
             return False
         try:
+            if not isinstance(self._isolation, PublisherIsolation) or not self._isolation.verify():
+                return False
             if _directory_anchor(self._root_fd) != self._root_anchor:
                 return False
             if _directory_anchor(self._git_fd) != self._git_anchor:
                 return False
             if _directory_anchor(self._steward_fd) != self._steward_anchor:
                 return False
-            lock_identity = _identity(os.fstat(self._lock.descriptor))
-            path_identity = _identity(os.stat(_LOCK, dir_fd=self._steward_fd, follow_symlinks=False))
-            return _same_identity(self._lock.identity, lock_identity) and _same_identity(lock_identity, path_identity)
+            lock_stat = os.fstat(self._lock.descriptor)
+            path_stat = os.stat(_LOCK, dir_fd=self._steward_fd, follow_symlinks=False)
+            lock_identity = _identity(lock_stat)
+            path_identity = _identity(path_stat)
+            owner = os.geteuid()
+            return (
+                lock_stat.st_uid == owner
+                and path_stat.st_uid == owner
+                and _same_identity(self._lock.identity, lock_identity)
+                and _same_identity(lock_identity, path_identity)
+            )
         except (OSError, ValueError):
             return False
 
@@ -461,28 +486,35 @@ def _acquire_lock(steward_fd: int, deadline: float) -> _HeldLock:
         raise
 
 
-def acquire_publisher_lease(repository_root: Path) -> PublisherLease:
-    """Acquire a pinned, private-worktree publication capability."""
+def acquire_publisher_lease(isolation: PublisherIsolation) -> PublisherLease:
+    """Consume an externally attested isolated worktree; never open a caller path."""
+    if not isinstance(isolation, PublisherIsolation) or not isolation.verify():
+        raise ValueError("publisher_isolation_required")
+    repository_root = isolation.repository_root
     if not isinstance(repository_root, Path) or not repository_root.is_absolute():
         raise ValueError("repository_path_invalid")
     root_fd = steward_fd = git_fd = None
     lock: _HeldLock | None = None
     deadline = time.monotonic() + _DEADLINE_SECONDS
     try:
-        root_fd = observer._open_repository_root(repository_root)
-        steward_fd = _open_steward(root_fd)
-        git_fd = _open_git(root_fd)
+        root_fd = os.dup(isolation.root_fd)
+        steward_fd = os.dup(isolation.steward_fd)
+        git_fd = os.dup(isolation.git_fd)
+        for descriptor in (root_fd, steward_fd, git_fd):
+            os.set_inheritable(descriptor, False)
         _directory_anchor(root_fd)
         _directory_anchor(steward_fd)
         _directory_anchor(git_fd)
         _safe_git()
         lock = _acquire_lock(steward_fd, deadline)
+        if not isolation.verify():
+            raise ValueError("publisher_isolation_changed")
         anchors = (
             _directory_anchor(root_fd),
             _directory_anchor(git_fd),
             _directory_anchor(steward_fd),
         )
-        return PublisherLease(_LEASE_TOKEN, repository_root, root_fd, git_fd, steward_fd, lock, anchors, deadline)
+        return PublisherLease(_LEASE_TOKEN, isolation, root_fd, git_fd, steward_fd, lock, anchors, deadline)
     except Exception:
         if lock is not None:
             lock.close()
@@ -563,6 +595,34 @@ def _same_git_view(left: _View, right: _View) -> bool:
         and left.head_blobs == right.head_blobs
         and left.layout == right.layout
     )
+
+
+def _final_no_op_fence(
+    root_fd: int,
+    git_fd: int,
+    steward_fd: int,
+    attestation: ConstitutionAttestation,
+    git: str,
+    deadline: float,
+    baseline: _View,
+    candidates: PublicationCandidates,
+    lease: PublisherLease,
+) -> None:
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
+    journals, temps, unknown = _scan_namespace(root_fd, steward_fd)
+    if journals or temps or unknown:
+        raise ValueError("transaction_namespace_changed")
+    final = _view(root_fd, git_fd, steward_fd, attestation, git, deadline)
+    if final.state is not observer.GenerationState.VALID or not _same_view(baseline, final):
+        raise ValueError("no_op_fence_changed")
+    for path in _TARGETS:
+        parent_fd, name = _parent_fd(root_fd, steward_fd, path)
+        state = _safe_file_state(parent_fd, name, PERSISTED_TARGET_MAX_BYTES[path])
+        if state is None or state.data != _candidate_bytes(candidates, path):
+            raise ValueError("no_op_target_changed")
+    if not lease.verify():
+        raise ValueError("publisher_lease_changed")
 
 
 def _candidate_metadata(candidates: PublicationCandidates) -> tuple[str, str, str]:
@@ -897,11 +957,11 @@ def _prepare_temp(
         raise ValueError("temp_changed")
     os.fsync(parent_fd)
     journal["temps"][path] = {**temp_identity, "candidate_sha256": hashlib.sha256(data).hexdigest()}
-    _advance_parent_bindings_after_own_mutation(journal, root_fd, steward_fd, parent_fd, prior_parent)
+    _verify_parent_unchanged_after_own_mutation(journal, root_fd, steward_fd, parent_fd, prior_parent)
     _write_journal(journal_fd, steward_fd, journal, lease)
 
 
-def _advance_parent_bindings_after_own_mutation(
+def _verify_parent_unchanged_after_own_mutation(
     journal: dict[str, object],
     root_fd: int,
     steward_fd: int,
@@ -909,7 +969,7 @@ def _advance_parent_bindings_after_own_mutation(
     prior_parent: Mapping[str, int | str],
 ) -> None:
     current_parent = _parent_identity(parent_fd)
-    if not all(current_parent.get(key) == prior_parent.get(key) for key in ("device", "inode", "type", "mode")):
+    if not _same_identity(dict(prior_parent), current_parent):
         raise ValueError("parent_changed")
     targets = journal["targets"]
     for target_path in _TARGETS:
@@ -917,16 +977,12 @@ def _advance_parent_bindings_after_own_mutation(
         if target_parent_fd == parent_fd:
             if not _same_identity(targets[target_path]["parent"], prior_parent):
                 raise ValueError("parent_changed")
-            targets[target_path]["parent"]["link_count"] = current_parent["link_count"]
-            targets[target_path]["baseline"]["parent"]["link_count"] = current_parent["link_count"]
     if parent_fd == root_fd:
         if not _same_identity(journal["repository"]["root"], prior_parent):
             raise ValueError("parent_changed")
-        journal["repository"]["root"]["link_count"] = current_parent["link_count"]
     elif parent_fd == steward_fd:
         if not _same_identity(journal["repository"]["steward"], prior_parent):
             raise ValueError("parent_changed")
-        journal["repository"]["steward"]["link_count"] = current_parent["link_count"]
 
 
 def _fence_parent(root_fd: int, steward_fd: int, path: str, expected: Mapping[str, object]) -> int:
@@ -1017,7 +1073,7 @@ def _replace_one(
     if installed is None or installed.data != _candidate_bytes(candidates, path):
         raise ValueError("readback_failed")
     os.fsync(parent_fd)
-    _advance_parent_bindings_after_own_mutation(journal, root_fd, steward_fd, parent_fd, prior_parent)
+    _verify_parent_unchanged_after_own_mutation(journal, root_fd, steward_fd, parent_fd, prior_parent)
     if not lease.verify():
         raise ValueError("publisher_lease_changed")
     record["installed"] = {**installed.identity, "candidate_sha256": hashlib.sha256(installed.data).hexdigest()}
@@ -1289,6 +1345,7 @@ def _prepare_recovery_temp(
 ) -> tuple[int, str]:
     parent_kind, name = _temp_name(path, journal["txid"])
     parent_fd = root_fd if parent_kind == 0 else steward_fd
+    prior_parent = _parent_identity(parent_fd)
     if not lease.verify():
         raise ValueError("publisher_lease_changed")
     if _safe_file_state(parent_fd, name, PERSISTED_TARGET_MAX_BYTES[path]) is not None:
@@ -1318,6 +1375,8 @@ def _prepare_recovery_temp(
     if check is None or check.data != data or check.identity != identity:
         raise ValueError("recovery_temp_changed")
     os.fsync(parent_fd)
+    if not _same_identity(prior_parent, _parent_identity(parent_fd)):
+        raise ValueError("recovery_parent_changed")
     if not lease.verify():
         raise ValueError("publisher_lease_changed")
     return parent_fd, name
@@ -1359,12 +1418,14 @@ def _rollback_partial_transaction(
                 raise ValueError("publisher_lease_changed")
             if _safe_file_state(parent_fd, target_name, PERSISTED_TARGET_MAX_BYTES[path]) is not None:
                 raise ValueError("recovery_unlink_failed")
+            if not _same_identity(parent_states[int(parent_fd)], _parent_identity(parent_fd)):
+                raise ValueError("recovery_parent_changed")
         else:
             _, temp_name = _prepare_recovery_temp(root_fd, steward_fd, journal, path, data, lease)
-            parent_states[int(parent_fd)] = _parent_identity(parent_fd)
             _fence_recovery_state(root_fd, steward_fd, journal, candidates, view, cursor, restored, parent_states)
             if not lease.verify():
                 raise ValueError("publisher_lease_changed")
+            prior_parent = _parent_identity(parent_fd)
             os.replace(temp_name, target_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
             descriptor = os.open(target_name, _OPEN_FILE, dir_fd=parent_fd)
             try:
@@ -1382,7 +1443,8 @@ def _rollback_partial_transaction(
             os.fsync(parent_fd)
             if not lease.verify():
                 raise ValueError("publisher_lease_changed")
-        parent_states[int(parent_fd)] = _parent_identity(parent_fd)
+            if not _same_identity(prior_parent, _parent_identity(parent_fd)):
+                raise ValueError("recovery_parent_changed")
         restored.add(path)
         current = _view(root_fd, git_fd, steward_fd, attestation, _safe_git()[0], deadline)
         if not _same_git_view(view, current) or not lease.verify():
@@ -1584,6 +1646,20 @@ def publish_context(
                 current_states[path] is not None and current_states[path].data == _candidate_bytes(candidates, path)
                 for path in _TARGETS
             ):
+                try:
+                    _final_no_op_fence(
+                        root_fd,
+                        git_fd,
+                        steward_fd,
+                        attestation,
+                        git,
+                        deadline,
+                        before,
+                        candidates,
+                        lease,
+                    )
+                except (OSError, ValueError, ContractViolation, TimeoutError, observer._ObservationFailure) as error:
+                    return _result(PublicationState.MANUAL_REVIEW, str(error) or type(error).__name__.lower())
                 return _result(PublicationState.NO_OP, "already_published")
         result = _create_transaction(root_fd, git_fd, steward_fd, after, candidates, attestation, lease)
         if result.state in {PublicationState.PUBLISHED, PublicationState.NO_OP} and not lease.verify():

--- a/tests/test_context_publication.py
+++ b/tests/test_context_publication.py
@@ -31,6 +31,41 @@ GIT_ENV = {
     "PATH": "/usr/bin:/bin",
 }
 
+DARWIN_MUTATION_UNSUPPORTED = pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="D2b canonical mutation requires the reviewed Linux isolation contract",
+)
+
+
+class FixtureIsolation:
+    def __init__(self, repository: Path):
+        self.repository_root = repository
+        self.root_fd = publication.observer._open_repository_root(repository)
+        self.steward_fd = publication._open_steward(self.root_fd)
+        self.git_fd = publication._open_git(self.root_fd)
+        self._anchors = (
+            publication._directory_anchor(self.root_fd),
+            publication._directory_anchor(self.git_fd),
+            publication._directory_anchor(self.steward_fd),
+        )
+        self._valid = True
+
+    def verify(self) -> bool:
+        try:
+            if not self._valid:
+                return False
+            return (
+                publication._directory_anchor(self.root_fd),
+                publication._directory_anchor(self.git_fd),
+                publication._directory_anchor(self.steward_fd),
+            ) == self._anchors
+        except OSError:
+            return False
+
+    def close(self) -> None:
+        for descriptor in (self.git_fd, self.steward_fd, self.root_fd):
+            os.close(descriptor)
+
 
 def git(repository: Path, *arguments: str) -> str:
     return subprocess.run(
@@ -78,11 +113,13 @@ def candidates_and_attestation(models):
 
 
 def publish(repository, payload, snapshot, attestation):
-    lease = acquire_publisher_lease(repository)
+    isolation = FixtureIsolation(repository)
+    lease = acquire_publisher_lease(isolation)
     try:
         return publish_context(repository, payload, snapshot, attestation, mode=PublicationMode.CANONICAL, lease=lease)
     finally:
         lease.close()
+        isolation.close()
 
 
 def test_disabled_is_a_pure_no_write_gate(tmp_path, candidates_and_attestation):
@@ -119,13 +156,16 @@ def test_canonical_requires_explicit_isolated_worktree_attestation(tmp_path, can
     assert result.state is PublicationState.BLOCKED
     assert result.reason == "publisher_lease_required"
     assert not (repository / ".steward" / ".context-publish-v1.lock").exists()
+    with pytest.raises(ValueError, match="publisher_isolation_required"):
+        acquire_publisher_lease(repository)
 
 
 def test_closed_publisher_lease_cannot_publish(tmp_path, candidates_and_attestation):
     payload, snapshot, _, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
     commit_all(repository)
-    lease = acquire_publisher_lease(repository)
+    isolation = FixtureIsolation(repository)
+    lease = acquire_publisher_lease(isolation)
     lease.close()
 
     result = publish_context(
@@ -140,12 +180,14 @@ def test_closed_publisher_lease_cannot_publish(tmp_path, candidates_and_attestat
     assert result.state is PublicationState.BLOCKED
     assert result.reason == "publisher_lease_invalid"
     assert (repository / ".steward" / ".context-publish-v1.lock").exists()
+    isolation.close()
 
 
 def test_lock_path_replacement_invalidates_lease(tmp_path):
     repository = initialize_repository(tmp_path / "repo")
     commit_all(repository)
-    lease = acquire_publisher_lease(repository)
+    isolation = FixtureIsolation(repository)
+    lease = acquire_publisher_lease(isolation)
     lock_path = repository / ".steward" / publication._LOCK
     subprocess.run(
         [
@@ -159,6 +201,33 @@ def test_lock_path_replacement_invalidates_lease(tmp_path):
 
     assert not lease.verify()
     lease.close()
+    isolation.close()
+
+
+def test_lock_owner_change_invalidates_lease(tmp_path, monkeypatch):
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+    isolation = FixtureIsolation(repository)
+    lease = acquire_publisher_lease(isolation)
+    try:
+        monkeypatch.setattr(publication.os, "geteuid", lambda: os.getuid() + 1)
+        assert not lease.verify()
+    finally:
+        lease.close()
+        isolation.close()
+
+
+def test_external_isolation_capability_loss_invalidates_lease(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+    isolation = FixtureIsolation(repository)
+    lease = acquire_publisher_lease(isolation)
+    isolation._valid = False
+    try:
+        assert not lease.verify()
+    finally:
+        lease.close()
+        isolation.close()
 
 
 def test_legacy_bootstrap_never_auto_overwritten(tmp_path, candidates_and_attestation):
@@ -175,6 +244,7 @@ def test_legacy_bootstrap_never_auto_overwritten(tmp_path, candidates_and_attest
     assert not (repository / "AGENTS.md").exists()
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_canonical_absent_baseline_publishes_four_targets(tmp_path, candidates_and_attestation):
     payload, snapshot, candidates, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -210,6 +280,35 @@ def test_valid_head_bound_generation_is_no_op(tmp_path, candidates_and_attestati
     assert result.transaction_id is None
     assert not list(repository.glob(".context-publish-v1.*.tmp"))
     assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
+
+
+def test_no_op_rechecks_git_and_namespace_before_return(tmp_path, candidates_and_attestation, monkeypatch):
+    payload, snapshot, candidates, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "CLAUDE.md").write_bytes(candidates.claude_md)
+    (repository / "AGENTS.md").write_bytes(candidates.agents_md)
+    (repository / ".steward" / "context-snapshot.json").write_bytes(candidates.snapshot_artifact)
+    (repository / ".steward" / "context-publication.json").write_bytes(candidates.publication_artifact)
+    commit_all(repository)
+    original_view = publication._view
+    calls = 0
+
+    def mutate_on_final_view(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        view = original_view(*args, **kwargs)
+        if calls == 3:
+            (repository / "README.md").write_text("no-op race\n")
+            git(repository, "add", "README.md")
+            git(repository, "commit", "-qm", "no-op race")
+            view = original_view(*args, **kwargs)
+        return view
+
+    monkeypatch.setattr(publication, "_view", mutate_on_final_view)
+    result = publish(repository, payload, snapshot, attestation)
+
+    assert result.state is PublicationState.MANUAL_REVIEW
+    assert result.reason == "no_op_fence_changed"
 
 
 def test_unexpected_baseline_mode_is_not_overwritten(tmp_path, candidates_and_attestation):
@@ -262,6 +361,7 @@ def test_unknown_transaction_signal_fails_closed(tmp_path, candidates_and_attest
     assert (repository / ".context-publish-v1.foreign.signal").read_text() == "foreign\n"
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_namespace_is_scanned_only_after_lease_lock(tmp_path, candidates_and_attestation, monkeypatch):
     payload, snapshot, _, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -301,6 +401,7 @@ def test_recovery_rejects_incoherent_git_state():
         publication._validate_recovery_view_state("replacing", view)
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_prepared_transaction_recovers_without_target_mutation(tmp_path, candidates_and_attestation, monkeypatch):
     payload, snapshot, _, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -326,6 +427,7 @@ def test_prepared_transaction_recovers_without_target_mutation(tmp_path, candida
     assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_partial_replace_recovers_four_file_absent_baseline(tmp_path, candidates_and_attestation, monkeypatch):
     payload, snapshot, candidates, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -354,6 +456,7 @@ def test_partial_replace_recovers_four_file_absent_baseline(tmp_path, candidates
     assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_partial_replace_restores_present_baseline(tmp_path, candidates_and_attestation, monkeypatch):
     payload, snapshot, candidates, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -388,6 +491,7 @@ def test_partial_replace_restores_present_baseline(tmp_path, candidates_and_atte
     assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_head_change_between_replacements_stops_transaction(tmp_path, candidates_and_attestation, monkeypatch):
     payload, snapshot, candidates, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -413,6 +517,7 @@ def test_head_change_between_replacements_stops_transaction(tmp_path, candidates
     assert list((repository / ".steward").glob(".context-publish-v1.*.txn"))
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_external_target_writer_is_fenced(tmp_path, candidates_and_attestation, monkeypatch):
     payload, snapshot, _, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")

--- a/tests/test_context_publication.py
+++ b/tests/test_context_publication.py
@@ -187,6 +187,31 @@ def test_canonical_is_blocked_on_unsupported_darwin(tmp_path, candidates_and_att
     assert not (repository / ".steward" / publication._LOCK).exists()
 
 
+def test_isolation_rejects_directory_fds_from_different_repositories(tmp_path):
+    first = initialize_repository(tmp_path / "first")
+    second = initialize_repository(tmp_path / "second")
+    commit_all(first)
+    commit_all(second)
+    root_fd = publication.observer._open_repository_root(first)
+    git_fd = publication._open_git(root_fd)
+    foreign_root_fd = publication.observer._open_repository_root(second)
+    steward_fd = publication._open_steward(foreign_root_fd)
+    try:
+        with pytest.raises(ValueError, match="isolation_repository_binding"):
+            publication.PublisherIsolation(
+                publication._ISOLATION_TOKEN,
+                first,
+                root_fd,
+                git_fd,
+                steward_fd,
+            )
+    finally:
+        os.close(git_fd)
+        os.close(steward_fd)
+        os.close(root_fd)
+        os.close(foreign_root_fd)
+
+
 def test_closed_publisher_lease_cannot_publish(tmp_path, candidates_and_attestation):
     payload, snapshot, _, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")

--- a/tests/test_context_publication.py
+++ b/tests/test_context_publication.py
@@ -6,6 +6,7 @@ import copy
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -141,6 +142,25 @@ def test_closed_publisher_lease_cannot_publish(tmp_path, candidates_and_attestat
     assert (repository / ".steward" / ".context-publish-v1.lock").exists()
 
 
+def test_lock_path_replacement_invalidates_lease(tmp_path):
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+    lease = acquire_publisher_lease(repository)
+    lock_path = repository / ".steward" / publication._LOCK
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from pathlib import Path; import sys; p=Path(sys.argv[1]); p.unlink(); p.touch(mode=0o600)",
+            str(lock_path),
+        ],
+        check=True,
+    )
+
+    assert not lease.verify()
+    lease.close()
+
+
 def test_legacy_bootstrap_never_auto_overwritten(tmp_path, candidates_and_attestation):
     payload, snapshot, _, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -265,6 +285,22 @@ def test_namespace_is_scanned_only_after_lease_lock(tmp_path, candidates_and_att
     assert lock_seen and all(lock_seen)
 
 
+def test_recovery_rejects_incoherent_git_state():
+    view = type(
+        "RecoveryView",
+        (),
+        {
+            "tree": {"CLAUDE.md": "head"},
+            "index": {},
+            "reason": "index_differs_from_head",
+            "state": publication.observer.GenerationState.MANUAL_REVIEW,
+        },
+    )()
+
+    with pytest.raises(ValueError, match="recovery_git_state_untrusted"):
+        publication._validate_recovery_view_state("replacing", view)
+
+
 def test_prepared_transaction_recovers_without_target_mutation(tmp_path, candidates_and_attestation, monkeypatch):
     payload, snapshot, _, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -375,6 +411,31 @@ def test_head_change_between_replacements_stops_transaction(tmp_path, candidates
     assert result.state is PublicationState.MANUAL_REVIEW
     assert (repository / "CLAUDE.md").read_bytes() == candidates.claude_md
     assert list((repository / ".steward").glob(".context-publish-v1.*.txn"))
+
+
+def test_external_target_writer_is_fenced(tmp_path, candidates_and_attestation, monkeypatch):
+    payload, snapshot, _, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+    original_replace = publication._replace_one
+
+    def replace_after_external_writer(*args, **kwargs):
+        subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from pathlib import Path; Path(__import__('sys').argv[1]).write_bytes(b'foreign')",
+                str(repository / "CLAUDE.md"),
+            ],
+            check=True,
+        )
+        return original_replace(*args, **kwargs)
+
+    monkeypatch.setattr(publication, "_replace_one", replace_after_external_writer)
+    result = publish(repository, payload, snapshot, attestation)
+
+    assert result.state is PublicationState.MANUAL_REVIEW
+    assert (repository / "CLAUDE.md").read_bytes() == b"foreign"
 
 
 def test_foreign_candidate_binding_preserves_journal(tmp_path, candidates_and_attestation, monkeypatch):

--- a/tests/test_context_publication.py
+++ b/tests/test_context_publication.py
@@ -37,34 +37,40 @@ DARWIN_MUTATION_UNSUPPORTED = pytest.mark.skipif(
 )
 
 
-class FixtureIsolation:
+class FixtureIsolation(publication.PublisherIsolation):
     def __init__(self, repository: Path):
-        self.repository_root = repository
-        self.root_fd = publication.observer._open_repository_root(repository)
-        self.steward_fd = publication._open_steward(self.root_fd)
-        self.git_fd = publication._open_git(self.root_fd)
-        self._anchors = (
-            publication._directory_anchor(self.root_fd),
-            publication._directory_anchor(self.git_fd),
-            publication._directory_anchor(self.steward_fd),
-        )
+        root_fd = publication.observer._open_repository_root(repository)
+        steward_fd = publication._open_steward(root_fd)
+        git_fd = publication._open_git(root_fd)
+        try:
+            super().__init__(
+                publication._ISOLATION_TOKEN,
+                repository,
+                root_fd,
+                git_fd,
+                steward_fd,
+            )
+        except Exception:
+            for descriptor in (git_fd, steward_fd, root_fd):
+                os.close(descriptor)
+            raise
         self._valid = True
 
     def verify(self) -> bool:
-        try:
-            if not self._valid:
-                return False
-            return (
-                publication._directory_anchor(self.root_fd),
-                publication._directory_anchor(self.git_fd),
-                publication._directory_anchor(self.steward_fd),
-            ) == self._anchors
-        except OSError:
-            return False
+        return self._valid and super().verify()
 
     def close(self) -> None:
-        for descriptor in (self.git_fd, self.steward_fd, self.root_fd):
-            os.close(descriptor)
+        super().close()
+
+
+class UnforgeableIsolationAttempt:
+    repository_root = Path("/tmp/forged")
+    root_fd = -1
+    git_fd = -1
+    steward_fd = -1
+
+    def verify(self) -> bool:
+        return True
 
 
 def git(repository: Path, *arguments: str) -> str:
@@ -153,11 +159,32 @@ def test_canonical_requires_explicit_isolated_worktree_attestation(tmp_path, can
 
     result = publish_context(repository, payload, snapshot, attestation, mode="canonical")
 
-    assert result.state is PublicationState.BLOCKED
-    assert result.reason == "publisher_lease_required"
+    if sys.platform == "darwin":
+        assert result.state is PublicationState.MANUAL_REVIEW
+        assert result.reason == "unsupported_platform"
+    else:
+        assert result.state is PublicationState.BLOCKED
+        assert result.reason == "publisher_lease_required"
     assert not (repository / ".steward" / ".context-publish-v1.lock").exists()
     with pytest.raises(ValueError, match="publisher_isolation_required"):
         acquire_publisher_lease(repository)
+    with pytest.raises(ValueError, match="publisher_isolation_required"):
+        acquire_publisher_lease(UnforgeableIsolationAttempt())
+    with pytest.raises(TypeError, match="isolation_constructor_private"):
+        publication.PublisherIsolation(object(), repository, -1, -1, -1)
+
+
+def test_canonical_is_blocked_on_unsupported_darwin(tmp_path, candidates_and_attestation, monkeypatch):
+    payload, snapshot, _, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+    monkeypatch.setattr(publication.sys, "platform", "darwin")
+
+    result = publish_context(repository, payload, snapshot, attestation, mode=PublicationMode.CANONICAL)
+
+    assert result.state is PublicationState.MANUAL_REVIEW
+    assert result.reason == "unsupported_platform"
+    assert not (repository / ".steward" / publication._LOCK).exists()
 
 
 def test_closed_publisher_lease_cannot_publish(tmp_path, candidates_and_attestation):
@@ -177,8 +204,12 @@ def test_closed_publisher_lease_cannot_publish(tmp_path, candidates_and_attestat
         lease=lease,
     )
 
-    assert result.state is PublicationState.BLOCKED
-    assert result.reason == "publisher_lease_invalid"
+    if sys.platform == "darwin":
+        assert result.state is PublicationState.MANUAL_REVIEW
+        assert result.reason == "unsupported_platform"
+    else:
+        assert result.state is PublicationState.BLOCKED
+        assert result.reason == "publisher_lease_invalid"
     assert (repository / ".steward" / ".context-publish-v1.lock").exists()
     isolation.close()
 
@@ -230,6 +261,7 @@ def test_external_isolation_capability_loss_invalidates_lease(tmp_path):
         isolation.close()
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_legacy_bootstrap_never_auto_overwritten(tmp_path, candidates_and_attestation):
     payload, snapshot, _, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -265,6 +297,7 @@ def test_canonical_absent_baseline_publishes_four_targets(tmp_path, candidates_a
     assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_valid_head_bound_generation_is_no_op(tmp_path, candidates_and_attestation):
     payload, snapshot, candidates, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -282,6 +315,7 @@ def test_valid_head_bound_generation_is_no_op(tmp_path, candidates_and_attestati
     assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_no_op_rechecks_git_and_namespace_before_return(tmp_path, candidates_and_attestation, monkeypatch):
     payload, snapshot, candidates, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -311,6 +345,7 @@ def test_no_op_rechecks_git_and_namespace_before_return(tmp_path, candidates_and
     assert result.reason == "no_op_fence_changed"
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_unexpected_baseline_mode_is_not_overwritten(tmp_path, candidates_and_attestation):
     payload, snapshot, candidates, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -331,6 +366,7 @@ def test_unexpected_baseline_mode_is_not_overwritten(tmp_path, candidates_and_at
     assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_unexpected_mode_is_not_reported_as_no_op(tmp_path, candidates_and_attestation):
     payload, snapshot, candidates, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -348,6 +384,7 @@ def test_unexpected_mode_is_not_reported_as_no_op(tmp_path, candidates_and_attes
     assert (repository / "CLAUDE.md").stat().st_mode & 0o777 == 0o600
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_unknown_transaction_signal_fails_closed(tmp_path, candidates_and_attestation):
     payload, snapshot, _, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -543,6 +580,7 @@ def test_external_target_writer_is_fenced(tmp_path, candidates_and_attestation, 
     assert (repository / "CLAUDE.md").read_bytes() == b"foreign"
 
 
+@DARWIN_MUTATION_UNSUPPORTED
 def test_foreign_candidate_binding_preserves_journal(tmp_path, candidates_and_attestation, monkeypatch):
     payload, snapshot, _, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")

--- a/tests/test_context_publication.py
+++ b/tests/test_context_publication.py
@@ -1,0 +1,261 @@
+"""Direct tests for the uncalled D2b transaction primitive."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import steward.context_publication as publication
+from steward.context_contract import ConstitutionAttestation
+from steward.context_publication import PublicationMode, PublicationState, publish_context
+from steward.context_rendering import build_publication_candidates
+
+GIT = "/usr/bin/git"
+GIT_ENV = {
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_NOSYSTEM": "1",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "LANG": "C",
+    "LC_ALL": "C",
+    "PATH": "/usr/bin:/bin",
+}
+
+
+def git(repository: Path, *arguments: str) -> str:
+    return subprocess.run(
+        [GIT, *arguments],
+        cwd=repository,
+        env=GIT_ENV,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def initialize_repository(path: Path) -> Path:
+    path.mkdir()
+    git(path, "init", "-q")
+    git(path, "config", "user.name", "Context Publication Test")
+    git(path, "config", "user.email", "context-publication@example.invalid")
+    (path / ".steward").mkdir()
+    (path / "README.md").write_text("fixture\n")
+    return path
+
+
+def commit_all(repository: Path) -> None:
+    git(repository, "add", "-A")
+    git(repository, "commit", "-qm", "fixture")
+
+
+@pytest.fixture
+def models():
+    vectors = json.loads(Path("specs/context_bridge_evidence/FEATURE_04_HASH_VECTORS.json").read_text())
+    return vectors["payload"]["model"], vectors["snapshot"]["model"]
+
+
+@pytest.fixture
+def candidates_and_attestation(models):
+    payload, snapshot = models
+    candidates = build_publication_candidates(payload, snapshot)
+    constitution = json.loads(candidates.snapshot_artifact)["snapshot"]["constitution"]
+    attestation = ConstitutionAttestation(
+        c0_sha256=constitution["sha256"],
+        source_blob=constitution["source_blob"],
+        reviewed_at_commit=constitution["reviewed_at_commit"],
+    )
+    return payload, snapshot, candidates, attestation
+
+
+def publish(repository, payload, snapshot, attestation):
+    return publish_context(
+        repository,
+        payload,
+        snapshot,
+        attestation,
+        mode=PublicationMode.CANONICAL,
+        isolation_attested=True,
+    )
+
+
+def test_disabled_is_a_pure_no_write_gate(tmp_path, candidates_and_attestation):
+    payload, snapshot, _, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+    result = publish_context(repository, payload, snapshot, attestation)
+
+    assert result.state is PublicationState.BLOCKED
+    assert result.reason == "disabled"
+    assert not (repository / ".steward" / ".context-publish-v1.lock").exists()
+
+
+def test_preview_validates_without_transaction_paths(tmp_path, candidates_and_attestation):
+    payload, snapshot, _, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+
+    result = publish_context(repository, payload, snapshot, attestation, mode="preview")
+
+    assert result.state is PublicationState.BLOCKED
+    assert result.reason == "preview_only"
+    assert not list(repository.glob(".context-publish-v1.*"))
+    assert not list((repository / ".steward").glob(".context-publish-v1.*"))
+
+
+def test_canonical_requires_explicit_isolated_worktree_attestation(tmp_path, candidates_and_attestation):
+    payload, snapshot, _, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+
+    result = publish_context(repository, payload, snapshot, attestation, mode="canonical")
+
+    assert result.state is PublicationState.BLOCKED
+    assert result.reason == "isolation_not_attested"
+    assert not (repository / ".steward" / ".context-publish-v1.lock").exists()
+
+
+def test_legacy_bootstrap_never_auto_overwritten(tmp_path, candidates_and_attestation):
+    payload, snapshot, _, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "CLAUDE.md").write_text("legacy\n")
+    commit_all(repository)
+
+    result = publish(repository, payload, snapshot, attestation)
+
+    assert result.state is PublicationState.MANUAL_REVIEW
+    assert result.reason == "baseline_legacy_bootstrap"
+    assert (repository / "CLAUDE.md").read_text() == "legacy\n"
+    assert not (repository / "AGENTS.md").exists()
+
+
+def test_canonical_absent_baseline_publishes_four_targets(tmp_path, candidates_and_attestation):
+    payload, snapshot, candidates, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "README.md").write_text("fixture\n")
+    commit_all(repository)
+
+    result = publish(repository, payload, snapshot, attestation)
+
+    assert result.state is PublicationState.PUBLISHED
+    assert result.transaction_id is not None
+    assert (repository / "CLAUDE.md").read_bytes() == candidates.claude_md
+    assert (repository / "AGENTS.md").read_bytes() == candidates.agents_md
+    assert (repository / ".steward" / "context-snapshot.json").read_bytes() == candidates.snapshot_artifact
+    assert (repository / ".steward" / "context-publication.json").read_bytes() == candidates.publication_artifact
+    assert (repository / "CLAUDE.md").stat().st_mode & 0o777 == 0o644
+    assert (repository / ".steward" / ".context-publish-v1.lock").exists()
+    assert not list(repository.glob(".context-publish-v1.*.tmp"))
+    assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
+
+
+def test_valid_head_bound_generation_is_no_op(tmp_path, candidates_and_attestation):
+    payload, snapshot, candidates, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "CLAUDE.md").write_bytes(candidates.claude_md)
+    (repository / "AGENTS.md").write_bytes(candidates.agents_md)
+    (repository / ".steward" / "context-snapshot.json").write_bytes(candidates.snapshot_artifact)
+    (repository / ".steward" / "context-publication.json").write_bytes(candidates.publication_artifact)
+    commit_all(repository)
+
+    result = publish(repository, payload, snapshot, attestation)
+
+    assert result.state is PublicationState.NO_OP
+    assert result.transaction_id is None
+    assert not list(repository.glob(".context-publish-v1.*.tmp"))
+    assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
+
+
+def test_unknown_transaction_signal_fails_closed(tmp_path, candidates_and_attestation):
+    payload, snapshot, _, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+    (repository / ".context-publish-v1.foreign.signal").write_text("foreign\n")
+
+    result = publish(repository, payload, snapshot, attestation)
+
+    assert result.state is PublicationState.MANUAL_REVIEW
+    assert result.reason == "transaction_namespace_ambiguous"
+    assert (repository / ".context-publish-v1.foreign.signal").read_text() == "foreign\n"
+
+
+def test_prepared_transaction_recovers_without_target_mutation(tmp_path, candidates_and_attestation, monkeypatch):
+    payload, snapshot, _, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+    original_replace = publication._replace_one
+
+    def interrupt_before_replace(*_args, **_kwargs):
+        raise ValueError("injected_prepare_crash")
+
+    monkeypatch.setattr(publication, "_replace_one", interrupt_before_replace)
+    first = publish(repository, payload, snapshot, attestation)
+    assert first.state is PublicationState.MANUAL_REVIEW
+    assert not (repository / "CLAUDE.md").exists()
+    journals = list((repository / ".steward").glob(".context-publish-v1.*.txn"))
+    assert len(journals) == 1
+
+    monkeypatch.setattr(publication, "_replace_one", original_replace)
+    recovered = publish(repository, payload, snapshot, attestation)
+    assert recovered.state is PublicationState.BLOCKED
+    assert recovered.reason == "recovered_prepared"
+    assert not (repository / "CLAUDE.md").exists()
+    assert not list(repository.glob(".context-publish-v1.*.tmp"))
+    assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
+
+
+def test_partial_replace_never_auto_recovers_or_deletes_evidence(tmp_path, candidates_and_attestation, monkeypatch):
+    payload, snapshot, candidates, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+    original_replace = publication._replace_one
+    calls = 0
+
+    def interrupt_after_first(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise ValueError("injected_partial_crash")
+        return original_replace(*args, **kwargs)
+
+    monkeypatch.setattr(publication, "_replace_one", interrupt_after_first)
+    first = publish(repository, payload, snapshot, attestation)
+    assert first.state is PublicationState.MANUAL_REVIEW
+    assert (repository / "CLAUDE.md").read_bytes() == candidates.claude_md
+
+    monkeypatch.setattr(publication, "_replace_one", original_replace)
+    second = publish(repository, payload, snapshot, attestation)
+    assert second.state is PublicationState.MANUAL_REVIEW
+    assert second.reason == "recovery_requires_review"
+    assert (repository / "CLAUDE.md").read_bytes() == candidates.claude_md
+    assert not (repository / "AGENTS.md").exists()
+    assert list((repository / ".steward").glob(".context-publish-v1.*.txn"))
+
+
+def test_foreign_candidate_binding_preserves_journal(tmp_path, candidates_and_attestation, monkeypatch):
+    payload, snapshot, _, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+    original_replace = publication._replace_one
+    monkeypatch.setattr(
+        publication, "_replace_one", lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("injected"))
+    )
+    publish(repository, payload, snapshot, attestation)
+    monkeypatch.setattr(publication, "_replace_one", original_replace)
+
+    journal_path = next((repository / ".steward").glob(".context-publish-v1.*.txn"))
+    journal = json.loads(journal_path.read_bytes())
+    journal["payload_hash"] = "0" * 64
+    journal_path.write_bytes(json.dumps(journal, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+    result = publish(repository, payload, snapshot, attestation)
+    assert result.state is PublicationState.MANUAL_REVIEW
+    assert result.reason == "valueerror"
+    assert journal_path.exists()
+
+
+def test_transaction_module_has_no_registered_caller():
+    source = Path("steward/context_publication.py").read_text()
+
+    assert "context_publication" not in Path("steward/tool_providers.py").read_text()
+    assert "publish_context(" in source

--- a/tests/test_context_publication.py
+++ b/tests/test_context_publication.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import copy
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -10,7 +12,12 @@ import pytest
 
 import steward.context_publication as publication
 from steward.context_contract import ConstitutionAttestation
-from steward.context_publication import PublicationMode, PublicationState, publish_context
+from steward.context_publication import (
+    PublicationMode,
+    PublicationState,
+    acquire_publisher_lease,
+    publish_context,
+)
 from steward.context_rendering import build_publication_candidates
 
 GIT = "/usr/bin/git"
@@ -70,14 +77,11 @@ def candidates_and_attestation(models):
 
 
 def publish(repository, payload, snapshot, attestation):
-    return publish_context(
-        repository,
-        payload,
-        snapshot,
-        attestation,
-        mode=PublicationMode.CANONICAL,
-        isolation_attested=True,
-    )
+    lease = acquire_publisher_lease(repository)
+    try:
+        return publish_context(repository, payload, snapshot, attestation, mode=PublicationMode.CANONICAL, lease=lease)
+    finally:
+        lease.close()
 
 
 def test_disabled_is_a_pure_no_write_gate(tmp_path, candidates_and_attestation):
@@ -112,8 +116,29 @@ def test_canonical_requires_explicit_isolated_worktree_attestation(tmp_path, can
     result = publish_context(repository, payload, snapshot, attestation, mode="canonical")
 
     assert result.state is PublicationState.BLOCKED
-    assert result.reason == "isolation_not_attested"
+    assert result.reason == "publisher_lease_required"
     assert not (repository / ".steward" / ".context-publish-v1.lock").exists()
+
+
+def test_closed_publisher_lease_cannot_publish(tmp_path, candidates_and_attestation):
+    payload, snapshot, _, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+    lease = acquire_publisher_lease(repository)
+    lease.close()
+
+    result = publish_context(
+        repository,
+        payload,
+        snapshot,
+        attestation,
+        mode=PublicationMode.CANONICAL,
+        lease=lease,
+    )
+
+    assert result.state is PublicationState.BLOCKED
+    assert result.reason == "publisher_lease_invalid"
+    assert (repository / ".steward" / ".context-publish-v1.lock").exists()
 
 
 def test_legacy_bootstrap_never_auto_overwritten(tmp_path, candidates_and_attestation):
@@ -167,6 +192,43 @@ def test_valid_head_bound_generation_is_no_op(tmp_path, candidates_and_attestati
     assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
 
 
+def test_unexpected_baseline_mode_is_not_overwritten(tmp_path, candidates_and_attestation):
+    payload, snapshot, candidates, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "CLAUDE.md").write_bytes(candidates.claude_md)
+    (repository / "AGENTS.md").write_bytes(candidates.agents_md)
+    (repository / ".steward" / "context-snapshot.json").write_bytes(candidates.snapshot_artifact)
+    (repository / ".steward" / "context-publication.json").write_bytes(candidates.publication_artifact)
+    commit_all(repository)
+    (repository / "CLAUDE.md").chmod(0o600)
+    next_snapshot = copy.deepcopy(snapshot)
+    next_snapshot["assembled_at"] = "2026-07-16T00:00:00Z"
+
+    result = publish(repository, payload, next_snapshot, attestation)
+
+    assert result.state is PublicationState.MANUAL_REVIEW
+    assert result.reason == "baseline_mode_unexpected"
+    assert (repository / "CLAUDE.md").stat().st_mode & 0o777 == 0o600
+    assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
+
+
+def test_unexpected_mode_is_not_reported_as_no_op(tmp_path, candidates_and_attestation):
+    payload, snapshot, candidates, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "CLAUDE.md").write_bytes(candidates.claude_md)
+    (repository / "AGENTS.md").write_bytes(candidates.agents_md)
+    (repository / ".steward" / "context-snapshot.json").write_bytes(candidates.snapshot_artifact)
+    (repository / ".steward" / "context-publication.json").write_bytes(candidates.publication_artifact)
+    commit_all(repository)
+    (repository / "CLAUDE.md").chmod(0o600)
+
+    result = publish(repository, payload, snapshot, attestation)
+
+    assert result.state is PublicationState.MANUAL_REVIEW
+    assert result.reason == "baseline_mode_unexpected"
+    assert (repository / "CLAUDE.md").stat().st_mode & 0o777 == 0o600
+
+
 def test_unknown_transaction_signal_fails_closed(tmp_path, candidates_and_attestation):
     payload, snapshot, _, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
@@ -178,6 +240,29 @@ def test_unknown_transaction_signal_fails_closed(tmp_path, candidates_and_attest
     assert result.state is PublicationState.MANUAL_REVIEW
     assert result.reason == "transaction_namespace_ambiguous"
     assert (repository / ".context-publish-v1.foreign.signal").read_text() == "foreign\n"
+
+
+def test_namespace_is_scanned_only_after_lease_lock(tmp_path, candidates_and_attestation, monkeypatch):
+    payload, snapshot, _, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+    original_scan = publication._scan_namespace
+    lock_seen: list[bool] = []
+
+    def scan_with_lock(root_fd, steward_fd):
+        try:
+            os.stat(publication._LOCK, dir_fd=steward_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            lock_seen.append(False)
+        else:
+            lock_seen.append(True)
+        return original_scan(root_fd, steward_fd)
+
+    monkeypatch.setattr(publication, "_scan_namespace", scan_with_lock)
+    result = publish(repository, payload, snapshot, attestation)
+
+    assert result.state is PublicationState.PUBLISHED
+    assert lock_seen and all(lock_seen)
 
 
 def test_prepared_transaction_recovers_without_target_mutation(tmp_path, candidates_and_attestation, monkeypatch):
@@ -205,7 +290,7 @@ def test_prepared_transaction_recovers_without_target_mutation(tmp_path, candida
     assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
 
 
-def test_partial_replace_never_auto_recovers_or_deletes_evidence(tmp_path, candidates_and_attestation, monkeypatch):
+def test_partial_replace_recovers_four_file_absent_baseline(tmp_path, candidates_and_attestation, monkeypatch):
     payload, snapshot, candidates, attestation = candidates_and_attestation
     repository = initialize_repository(tmp_path / "repo")
     commit_all(repository)
@@ -226,10 +311,69 @@ def test_partial_replace_never_auto_recovers_or_deletes_evidence(tmp_path, candi
 
     monkeypatch.setattr(publication, "_replace_one", original_replace)
     second = publish(repository, payload, snapshot, attestation)
-    assert second.state is PublicationState.MANUAL_REVIEW
-    assert second.reason == "recovery_requires_review"
-    assert (repository / "CLAUDE.md").read_bytes() == candidates.claude_md
+    assert second.state is PublicationState.BLOCKED
+    assert second.reason == "recovered_rollback"
+    assert not (repository / "CLAUDE.md").exists()
     assert not (repository / "AGENTS.md").exists()
+    assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
+
+
+def test_partial_replace_restores_present_baseline(tmp_path, candidates_and_attestation, monkeypatch):
+    payload, snapshot, candidates, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    (repository / "CLAUDE.md").write_bytes(candidates.claude_md)
+    (repository / "AGENTS.md").write_bytes(candidates.agents_md)
+    (repository / ".steward" / "context-snapshot.json").write_bytes(candidates.snapshot_artifact)
+    (repository / ".steward" / "context-publication.json").write_bytes(candidates.publication_artifact)
+    commit_all(repository)
+    next_snapshot = copy.deepcopy(snapshot)
+    next_snapshot["assembled_at"] = "2026-07-16T00:00:00Z"
+    original_replace = publication._replace_one
+    calls = 0
+
+    def interrupt_after_first(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise ValueError("injected_present_baseline_crash")
+        return original_replace(*args, **kwargs)
+
+    monkeypatch.setattr(publication, "_replace_one", interrupt_after_first)
+    first = publish(repository, payload, next_snapshot, attestation)
+    assert first.state is PublicationState.MANUAL_REVIEW
+    monkeypatch.setattr(publication, "_replace_one", original_replace)
+    recovered = publish(repository, payload, next_snapshot, attestation)
+    assert recovered.state is PublicationState.BLOCKED
+    assert recovered.reason == "recovered_rollback"
+    assert (repository / "CLAUDE.md").read_bytes() == candidates.claude_md
+    assert (repository / "AGENTS.md").read_bytes() == candidates.agents_md
+    assert (repository / ".steward" / "context-snapshot.json").read_bytes() == candidates.snapshot_artifact
+    assert (repository / ".steward" / "context-publication.json").read_bytes() == candidates.publication_artifact
+    assert not list((repository / ".steward").glob(".context-publish-v1.*.txn"))
+
+
+def test_head_change_between_replacements_stops_transaction(tmp_path, candidates_and_attestation, monkeypatch):
+    payload, snapshot, candidates, attestation = candidates_and_attestation
+    repository = initialize_repository(tmp_path / "repo")
+    commit_all(repository)
+    original_replace = publication._replace_one
+    calls = 0
+
+    def replace_then_commit(*args, **kwargs):
+        nonlocal calls
+        result = original_replace(*args, **kwargs)
+        calls += 1
+        if calls == 1:
+            (repository / "README.md").write_text("head changed\n")
+            git(repository, "add", "README.md")
+            git(repository, "commit", "-qm", "head changed")
+        return result
+
+    monkeypatch.setattr(publication, "_replace_one", replace_then_commit)
+    result = publish(repository, payload, snapshot, attestation)
+
+    assert result.state is PublicationState.MANUAL_REVIEW
+    assert (repository / "CLAUDE.md").read_bytes() == candidates.claude_md
     assert list((repository / ".steward").glob(".context-publish-v1.*.txn"))
 
 


### PR DESCRIPTION
## Scope

This PR implements the isolated, default-disabled D2b local transaction primitive described by the approved G2 contract.

Allowed paths only:
- `steward/context_publication.py`
- `tests/test_context_publication.py`

## Safety boundary

- `disabled` and `preview` modes are pure and perform no filesystem writes.
- `canonical` requires explicit isolated-worktree attestation.
- The primitive is not imported or registered by any existing caller.
- No workflow, writer tool, root file, runtime state, delivery, bootstrap activation, or remote push is changed.
- Existing D2a observer and Feature-04 renderer/validators are reused; no second parser or renderer is introduced.
- Lock, strict journal schema, fixed four-target transaction namespace, dirfd-relative temp/replace, read-back fences, and fail-closed recovery states are covered by direct tests.

## Validation

- Focused D2b tests: 11 passed.
- Full suite on the pre-rebase tree: 2375 passed, 15 skipped.
- Ruff and `git diff --check` clean.

This PR is intentionally not an activation or delivery change. It requires independent adversarial review before any merge or caller wiring.

## Latest hardening

`acquire_publisher_lease()` now consumes an externally attested `PublisherIsolation` capability and never opens an arbitrary repository path. The capability/bootstrap process and the external isolated-worktree drill are intentionally not implemented or wired in this PR; without that capability canonical publication remains unavailable.
