### PR TITLE
feat(moksha): Schnitt A cognition instrument (spec DRAFT 1.0, G1)

### DIFF
--- a/steward/hooks/moksha_health.py
+++ b/steward/hooks/moksha_health.py
@@ -48,6 +48,33 @@ def _quota_ok(q: dict | None) -> bool:
         raise _ShapeDrift(f"quota.get_status() shape: {e}") from e
 
 
+_version_validated = False
+
+
+def _validate_protocol_shape_once() -> None:
+    """Validate the installed steward-protocol get_status() shapes once (spec §5.3a).
+
+    Instantiates real CircuitBreaker/OperationalQuota and decodes their fresh
+    get_status() output through the same decoders the builder uses, so a
+    version drift is logged loudly at the first opportunity instead of only
+    surfacing later via a per-cycle decode_error.
+    """
+    global _version_validated
+    if _version_validated:
+        return
+    _version_validated = True
+    try:
+        from vibe_core.runtime.circuit_breaker import CircuitBreaker, CircuitBreakerConfig
+        from vibe_core.runtime.quota_manager import OperationalQuota
+
+        _breaker_ok(CircuitBreaker(CircuitBreakerConfig()).get_status())
+        _quota_ok(OperationalQuota().get_status())
+    except _ShapeDrift as e:
+        logger.error("cognition: steward-protocol status shape drift at startup: %s", e)
+    except Exception as e:  # import error, signature change, etc. -> loud, non-fatal
+        logger.warning("cognition: could not validate steward-protocol shape at startup: %s", e)
+
+
 class MokshaHealthReportHook(BasePhaseHook):
     """Write federation health snapshot after each MURALI cycle."""
 
@@ -64,6 +91,8 @@ class MokshaHealthReportHook(BasePhaseHook):
         return 40  # Before persistence (50) and federation flush (80)
 
     def execute(self, ctx: PhaseContext) -> None:
+        _validate_protocol_shape_once()
+
         prev = {"consecutive_collapsed_cycles": 0, "total_calls": 0, "total_failures": 0}
         try:
             _c = json.loads(_HEALTH_FILE.read_text()).get("cognition", {})
@@ -129,9 +158,17 @@ def _build_health_report(prev: dict | None = None) -> dict:
 
     prev = prev or {"consecutive_collapsed_cycles": 0, "total_calls": 0, "total_failures": 0}
     cog = {
-        "providers_alive": 0, "providers_total": 0, "providers_usable": 0,
-        "total_calls": 0, "total_failures": 0, "calls_delta": 0, "fail_delta": 0,
-        "hard_down": False, "degraded": False, "skip_collapse": False, "decode_error": None,
+        "providers_alive": 0,
+        "providers_total": 0,
+        "providers_usable": 0,
+        "total_calls": 0,
+        "total_failures": 0,
+        "calls_delta": 0,
+        "fail_delta": 0,
+        "hard_down": False,
+        "degraded": False,
+        "skip_collapse": False,
+        "decode_error": None,
         "consecutive_collapsed_cycles": prev["consecutive_collapsed_cycles"],
     }
     provider = ServiceRegistry.get(SVC_PROVIDER)
@@ -153,9 +190,7 @@ def _build_health_report(prev: dict | None = None) -> dict:
         degraded = cd == 0 and fd > 0  # failures but no success this cycle (§3 semantics)
         try:
             usable = sum(
-                1
-                for p in providers
-                if p.get("alive") and _breaker_ok(p.get("breaker")) and _quota_ok(ps.get("quota"))
+                1 for p in providers if p.get("alive") and _breaker_ok(p.get("breaker")) and _quota_ok(ps.get("quota"))
             )
             skip_collapse = total > 0 and usable == 0
             collapsed = hard_down or degraded or skip_collapse
@@ -163,18 +198,32 @@ def _build_health_report(prev: dict | None = None) -> dict:
         except _ShapeDrift as e:  # fail loud, not silently "healthy"
             logger.warning("cognition decode drift: %s", e)
             usable = 0
-            skip_collapse = False
+            skip_collapse = False  # undecodable, not claimed either way
             cog["decode_error"] = str(e)
-            streak = prev["consecutive_collapsed_cycles"]  # streak frozen, not guessed
-        cog.update({
-            "providers_alive": alive, "providers_total": total,
-            "providers_usable": usable,
-            "total_calls": tc, "total_failures": tf,
-            "calls_delta": cd, "fail_delta": fd,
-            "hard_down": hard_down, "degraded": degraded,
-            "skip_collapse": skip_collapse,
-            "consecutive_collapsed_cycles": streak,
-        })
+            if hard_down or degraded:
+                # hard_down/degraded are computed from alive/cd/fd, independent of the
+                # drifted breaker/quota shape — an unambiguous collapse signal must not
+                # be masked by an unrelated decode failure (Befund 1).
+                streak = prev["consecutive_collapsed_cycles"] + 1
+            else:
+                # skip_collapse is the only signal that depends on the drifted shape;
+                # with hard_down/degraded both False, the streak is genuinely undecidable.
+                streak = prev["consecutive_collapsed_cycles"]  # frozen, not guessed
+        cog.update(
+            {
+                "providers_alive": alive,
+                "providers_total": total,
+                "providers_usable": usable,
+                "total_calls": tc,
+                "total_failures": tf,
+                "calls_delta": cd,
+                "fail_delta": fd,
+                "hard_down": hard_down,
+                "degraded": degraded,
+                "skip_collapse": skip_collapse,
+                "consecutive_collapsed_cycles": streak,
+            }
+        )
     report["cognition"] = cog
 
     return report

--- a/steward/hooks/moksha_health.py
+++ b/steward/hooks/moksha_health.py
@@ -15,10 +15,37 @@ import time
 from pathlib import Path
 
 from steward.phase_hook import MOKSHA, BasePhaseHook, PhaseContext
-from steward.services import SVC_FEDERATION_GATEWAY, SVC_IMMUNE, SVC_REAPER
+from steward.services import SVC_FEDERATION_GATEWAY, SVC_IMMUNE, SVC_PROVIDER, SVC_REAPER
 from vibe_core.di import ServiceRegistry
 
 logger = logging.getLogger("STEWARD.HOOKS.MOKSHA_HEALTH")
+
+_HEALTH_FILE = Path(".steward/federation_health.json")
+
+
+class _ShapeDrift(Exception):
+    """steward-protocol get_status() shape deviates from the pinned form (spec §5.3a)."""
+
+
+def _breaker_ok(b: dict | None) -> bool:
+    if b is None:
+        return True  # no breaker for this provider = usable
+    if "state" not in b:  # fail loud instead of silently "healthy"
+        raise _ShapeDrift("breaker.get_status(): 'state' missing")
+    return b["state"] != "open"  # {closed, open, half_open}; skip only on OPEN
+
+
+def _quota_ok(q: dict | None) -> bool:
+    if not q:
+        return True
+    try:  # missing expected keys -> fail loud
+        return (
+            q["requests"]["percent_used"] < 100
+            and q["tokens"]["percent_used"] < 100
+            and q["cost"]["this_hour_usd"] < q["cost"]["limit_per_hour_usd"]
+        )
+    except (KeyError, TypeError) as e:
+        raise _ShapeDrift(f"quota.get_status() shape: {e}") from e
 
 
 class MokshaHealthReportHook(BasePhaseHook):
@@ -37,7 +64,16 @@ class MokshaHealthReportHook(BasePhaseHook):
         return 40  # Before persistence (50) and federation flush (80)
 
     def execute(self, ctx: PhaseContext) -> None:
-        report = _build_health_report()
+        prev = {"consecutive_collapsed_cycles": 0, "total_calls": 0, "total_failures": 0}
+        try:
+            _c = json.loads(_HEALTH_FILE.read_text()).get("cognition", {})
+            prev["consecutive_collapsed_cycles"] = _c.get("consecutive_collapsed_cycles", 0)
+            prev["total_calls"] = _c.get("total_calls", 0)
+            prev["total_failures"] = _c.get("total_failures", 0)
+        except (OSError, ValueError, TypeError):
+            pass  # missing/torn file -> defaults
+
+        report = _build_health_report(prev)
         payload = json.dumps(report, indent=2) + "\n"
 
         # Write to .steward/ (local state)
@@ -59,8 +95,8 @@ class MokshaHealthReportHook(BasePhaseHook):
         ctx.operations.append("moksha_health_report:ok")
 
 
-def _build_health_report() -> dict:
-    """Aggregate health data from reaper + immune + gateway."""
+def _build_health_report(prev: dict | None = None) -> dict:
+    """Aggregate health data from reaper + immune + gateway + cognition."""
     reaper = ServiceRegistry.get(SVC_REAPER)
     immune = ServiceRegistry.get(SVC_IMMUNE)
     gateway = ServiceRegistry.get(SVC_FEDERATION_GATEWAY)
@@ -90,5 +126,55 @@ def _build_health_report() -> dict:
 
     if gateway is not None:
         report["gateway"] = gateway.stats()
+
+    prev = prev or {"consecutive_collapsed_cycles": 0, "total_calls": 0, "total_failures": 0}
+    cog = {
+        "providers_alive": 0, "providers_total": 0, "providers_usable": 0,
+        "total_calls": 0, "total_failures": 0, "calls_delta": 0, "fail_delta": 0,
+        "hard_down": False, "degraded": False, "skip_collapse": False, "decode_error": None,
+        "consecutive_collapsed_cycles": prev["consecutive_collapsed_cycles"],
+    }
+    provider = ServiceRegistry.get(SVC_PROVIDER)
+    if provider is not None and hasattr(provider, "stats"):
+        ps = provider.stats()
+        providers = ps.get("providers", [])
+        alive = sum(1 for p in providers if p.get("alive"))
+        total = len(providers)
+        tc = ps.get("total_calls", 0)
+        tf = ps.get("total_failures", 0)
+        # Run boundary: fresh process resets totals to 0 -> delta = current totals
+        if tc >= prev["total_calls"]:
+            cd = tc - prev["total_calls"]
+            fd = tf - prev["total_failures"]
+        else:
+            cd = tc
+            fd = tf
+        hard_down = total > 0 and alive == 0
+        degraded = cd == 0 and fd > 0  # failures but no success this cycle (§3 semantics)
+        try:
+            usable = sum(
+                1
+                for p in providers
+                if p.get("alive") and _breaker_ok(p.get("breaker")) and _quota_ok(ps.get("quota"))
+            )
+            skip_collapse = total > 0 and usable == 0
+            collapsed = hard_down or degraded or skip_collapse
+            streak = prev["consecutive_collapsed_cycles"] + 1 if collapsed else 0
+        except _ShapeDrift as e:  # fail loud, not silently "healthy"
+            logger.warning("cognition decode drift: %s", e)
+            usable = 0
+            skip_collapse = False
+            cog["decode_error"] = str(e)
+            streak = prev["consecutive_collapsed_cycles"]  # streak frozen, not guessed
+        cog.update({
+            "providers_alive": alive, "providers_total": total,
+            "providers_usable": usable,
+            "total_calls": tc, "total_failures": tf,
+            "calls_delta": cd, "fail_delta": fd,
+            "hard_down": hard_down, "degraded": degraded,
+            "skip_collapse": skip_collapse,
+            "consecutive_collapsed_cycles": streak,
+        })
+    report["cognition"] = cog
 
     return report

--- a/tests/test_moksha_health.py
+++ b/tests/test_moksha_health.py
@@ -170,7 +170,31 @@ class TestCognitionBlock:
         cog = report["cognition"]
 
         assert cog["decode_error"] is not None
-        assert cog["consecutive_collapsed_cycles"] == 2  # frozen, not guessed
+        assert cog["hard_down"] is False
+        assert cog["degraded"] is False
+        assert cog["consecutive_collapsed_cycles"] == 2  # genuinely undecidable -> frozen
+
+    def test_decode_error_does_not_mask_degraded(self):
+        """Befund 1: an unambiguous collapse signal (degraded) must not be masked
+        by an unrelated breaker/quota shape drift — only the undecidable
+        skip_collapse signal is allowed to freeze the streak."""
+        stats = {
+            "providers": [
+                {"name": "p0", "alive": True, "breaker": {"failure_count": 0}},  # missing 'state'
+            ],
+            "total_calls": 0,
+            "total_failures": 1,  # fd=1, cd=0 -> degraded True regardless of decode drift
+            "quota": {},
+        }
+        ServiceRegistry.register(SVC_PROVIDER, StatsOnlyProvider(stats))
+
+        prev = {"consecutive_collapsed_cycles": 2, "total_calls": 0, "total_failures": 0}
+        report = _build_health_report(prev)
+        cog = report["cognition"]
+
+        assert cog["decode_error"] is not None
+        assert cog["degraded"] is True
+        assert cog["consecutive_collapsed_cycles"] == 3  # advanced, not frozen
 
 
 class TestDiskRoundtrip:
@@ -224,3 +248,71 @@ class TestDiskRoundtrip:
 
         assert result is None
         assert "moksha_health_report:ok" in ctx.operations
+
+
+class TestProtocolShapeValidation:
+    """Befund 3: spec §5.3a claims execute() validates the installed
+    steward-protocol shape once on first call — this must actually happen."""
+
+    def test_validate_protocol_shape_matches_installed_package(self):
+        """Re-runs the impl-step-1 version cross-check as a regression test:
+        the real installed steward-protocol get_status() shapes must decode
+        cleanly through the pinned decoders."""
+        from steward.hooks.moksha_health import _breaker_ok, _quota_ok
+        from vibe_core.runtime.circuit_breaker import CircuitBreaker, CircuitBreakerConfig
+        from vibe_core.runtime.quota_manager import OperationalQuota
+
+        assert _breaker_ok(CircuitBreaker(CircuitBreakerConfig()).get_status()) is True
+        assert _quota_ok(OperationalQuota().get_status()) is True
+
+    def test_validate_protocol_shape_once_sets_flag(self, monkeypatch):
+        import steward.hooks.moksha_health as mh
+
+        monkeypatch.setattr(mh, "_version_validated", False)
+        mh._validate_protocol_shape_once()
+        assert mh._version_validated is True
+
+    def test_validate_protocol_shape_runs_only_once(self, monkeypatch):
+        import steward.hooks.moksha_health as mh
+
+        monkeypatch.setattr(mh, "_version_validated", False)
+        calls = []
+        real_breaker_ok = mh._breaker_ok
+
+        def spy(b):
+            calls.append(b)
+            return real_breaker_ok(b)
+
+        monkeypatch.setattr(mh, "_breaker_ok", spy)
+        mh._validate_protocol_shape_once()
+        mh._validate_protocol_shape_once()
+        mh._validate_protocol_shape_once()
+
+        assert len(calls) == 1  # validated once, subsequent calls are no-ops
+
+    def test_execute_triggers_validation(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        import steward.hooks.moksha_health as mh
+
+        monkeypatch.setattr(mh, "_version_validated", False)
+        hook = MokshaHealthReportHook()
+        ctx = PhaseContext(cwd=str(tmp_path))
+
+        hook.execute(ctx)
+
+        assert mh._version_validated is True
+
+    def test_validate_protocol_shape_detects_drift(self, monkeypatch, caplog):
+        import logging
+
+        import steward.hooks.moksha_health as mh
+        from vibe_core.runtime.circuit_breaker import CircuitBreaker
+
+        monkeypatch.setattr(mh, "_version_validated", False)
+        monkeypatch.setattr(CircuitBreaker, "get_status", lambda self: {"failure_count": 0})
+
+        with caplog.at_level(logging.ERROR, logger="STEWARD.HOOKS.MOKSHA_HEALTH"):
+            mh._validate_protocol_shape_once()
+
+        assert mh._version_validated is True  # non-fatal: logged, not raised
+        assert any("shape drift" in r.message for r in caplog.records)

--- a/tests/test_moksha_health.py
+++ b/tests/test_moksha_health.py
@@ -1,0 +1,226 @@
+"""Tests for MokshaHealthReportHook cognition instrument (spec §6).
+
+Covers the `cognition` block in the health report: hard-down, degradation
+(cycle delta), skip-collapse, fail-loud decode drift, and disk roundtrip
+persistence of `consecutive_collapsed_cycles`.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from steward.hooks.moksha_health import MokshaHealthReportHook, _build_health_report
+from steward.phase_hook import PhaseContext
+from steward.provider.chamber import ProviderChamber
+from steward.services import SVC_PROVIDER
+from steward.types import LLMUsage
+from tests.fakes import FakeResponse
+from vibe_core.di import ServiceRegistry
+from vibe_core.mahamantra.protocols._seed import MAHA_QUANTUM
+
+
+class FakeProvider:
+    """Provider that always succeeds."""
+
+    def __init__(self, name: str = "fake") -> None:
+        self.name = name
+
+    def invoke(self, **kwargs: object) -> FakeResponse:
+        return FakeResponse(content=f"{self.name} response", usage=LLMUsage(input_tokens=10, output_tokens=5))
+
+
+class StatsOnlyProvider:
+    """Fake registered under SVC_PROVIDER exposing a raw crafted stats() dict."""
+
+    def __init__(self, stats: dict) -> None:
+        self._stats = stats
+
+    def stats(self) -> dict:
+        return self._stats
+
+
+def _chamber_with_alive(n: int) -> ProviderChamber:
+    chamber = ProviderChamber()
+    for i in range(n):
+        chamber.add_provider(
+            name=f"p{i}",
+            provider=FakeProvider(f"p{i}"),
+            model="test-model",
+            source_address=MAHA_QUANTUM * (10 + i),
+        )
+    return chamber
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    ServiceRegistry.reset_all()
+    yield
+    ServiceRegistry.reset_all()
+
+
+class TestCognitionBlock:
+    def test_cognition_block_healthy(self):
+        chamber = _chamber_with_alive(2)
+        ServiceRegistry.register(SVC_PROVIDER, chamber)
+
+        report = _build_health_report()
+        cog = report["cognition"]
+
+        assert cog["providers_alive"] == 2
+        assert cog["hard_down"] is False
+        assert cog["degraded"] is False
+        assert cog["consecutive_collapsed_cycles"] == 0
+
+    def test_hard_down_increments(self):
+        chamber = _chamber_with_alive(2)
+        for cell in chamber._cells:
+            cell.lifecycle.is_active = False
+        ServiceRegistry.register(SVC_PROVIDER, chamber)
+
+        prev = {"consecutive_collapsed_cycles": 3, "total_calls": 0, "total_failures": 0}
+        report = _build_health_report(prev)
+        cog = report["cognition"]
+
+        assert cog["hard_down"] is True
+        assert cog["consecutive_collapsed_cycles"] == 4
+
+    def test_degraded_increments(self):
+        chamber = _chamber_with_alive(1)
+        chamber._total_calls = 0
+        chamber._total_failures = 1  # failures, no success this cycle
+        ServiceRegistry.register(SVC_PROVIDER, chamber)
+
+        prev = {"consecutive_collapsed_cycles": 0, "total_calls": 0, "total_failures": 0}
+        report = _build_health_report(prev)
+        cog = report["cognition"]
+
+        assert cog["hard_down"] is False
+        assert cog["degraded"] is True
+        assert cog["consecutive_collapsed_cycles"] == 1
+
+    def test_healthy_fallback_stays_green(self):
+        """Dead predecessor + healthy fallback (cd>0, fd>0) stays green."""
+        chamber = _chamber_with_alive(1)
+        chamber._total_calls = 1
+        chamber._total_failures = 1
+        ServiceRegistry.register(SVC_PROVIDER, chamber)
+
+        prev = {"consecutive_collapsed_cycles": 5, "total_calls": 0, "total_failures": 0}
+        report = _build_health_report(prev)
+        cog = report["cognition"]
+
+        assert cog["degraded"] is False
+        assert cog["consecutive_collapsed_cycles"] == 0
+
+    def test_transient_resets(self):
+        chamber = _chamber_with_alive(1)
+        chamber._total_calls = 1
+        chamber._total_failures = 0
+        ServiceRegistry.register(SVC_PROVIDER, chamber)
+
+        prev = {"consecutive_collapsed_cycles": 5, "total_calls": 0, "total_failures": 0}
+        report = _build_health_report(prev)
+        cog = report["cognition"]
+
+        assert cog["hard_down"] is False
+        assert cog["degraded"] is False
+        assert cog["skip_collapse"] is False
+        assert cog["consecutive_collapsed_cycles"] == 0
+
+    def test_no_provider_registered(self):
+        prev = {"consecutive_collapsed_cycles": 5, "total_calls": 0, "total_failures": 0}
+        report = _build_health_report(prev)
+        cog = report["cognition"]
+
+        assert cog["providers_total"] == 0
+        assert cog["consecutive_collapsed_cycles"] == 5
+
+    def test_skip_collapse_breaker(self):
+        chamber = _chamber_with_alive(2)
+        for breaker in chamber._breakers.values():
+            for _ in range(5):
+                breaker._record_failure(Exception("down"))
+        ServiceRegistry.register(SVC_PROVIDER, chamber)
+
+        prev = {"consecutive_collapsed_cycles": 0, "total_calls": 0, "total_failures": 0}
+        report = _build_health_report(prev)
+        cog = report["cognition"]
+
+        assert cog["calls_delta"] == 0
+        assert cog["fail_delta"] == 0
+        assert cog["providers_usable"] == 0
+        assert cog["skip_collapse"] is True
+        assert cog["consecutive_collapsed_cycles"] == 1
+
+    def test_decode_error_fails_loud(self):
+        stats = {
+            "providers": [
+                {"name": "p0", "alive": True, "breaker": {"failure_count": 0}},  # missing 'state'
+            ],
+            "total_calls": 0,
+            "total_failures": 0,
+            "quota": {},
+        }
+        ServiceRegistry.register(SVC_PROVIDER, StatsOnlyProvider(stats))
+
+        prev = {"consecutive_collapsed_cycles": 2, "total_calls": 0, "total_failures": 0}
+        report = _build_health_report(prev)
+        cog = report["cognition"]
+
+        assert cog["decode_error"] is not None
+        assert cog["consecutive_collapsed_cycles"] == 2  # frozen, not guessed
+
+
+class TestDiskRoundtrip:
+    def test_roundtrip_increment(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        steward_dir = tmp_path / ".steward"
+        steward_dir.mkdir()
+        (steward_dir / "federation_health.json").write_text(
+            json.dumps({"cognition": {"consecutive_collapsed_cycles": 3, "total_calls": 0, "total_failures": 0}})
+        )
+
+        chamber = _chamber_with_alive(2)
+        for cell in chamber._cells:
+            cell.lifecycle.is_active = False
+        ServiceRegistry.register(SVC_PROVIDER, chamber)
+
+        hook = MokshaHealthReportHook()
+        ctx = PhaseContext(cwd=str(tmp_path))
+        hook.execute(ctx)
+
+        written = json.loads((steward_dir / "federation_health.json").read_text())
+        assert written["cognition"]["consecutive_collapsed_cycles"] == 4
+
+    def test_roundtrip_missing_and_torn(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        chamber = _chamber_with_alive(2)
+        ServiceRegistry.register(SVC_PROVIDER, chamber)
+
+        hook = MokshaHealthReportHook()
+        ctx = PhaseContext(cwd=str(tmp_path))
+        hook.execute(ctx)  # missing file -> defaults, no crash
+
+        steward_dir = tmp_path / ".steward"
+        (steward_dir / "federation_health.json").write_text("{not json")
+
+        hook.execute(ctx)  # torn file -> defaults, no crash
+
+        (steward_dir / "federation_health.json").write_text(json.dumps({"peers": {}}))
+
+        hook.execute(ctx)  # no cognition key -> defaults, no crash
+
+        written = json.loads((steward_dir / "federation_health.json").read_text())
+        assert written["cognition"]["consecutive_collapsed_cycles"] == 0
+
+    def test_execute_appends_ok_and_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        hook = MokshaHealthReportHook()
+        ctx = PhaseContext(cwd=str(tmp_path))
+
+        result = hook.execute(ctx)
+
+        assert result is None
+        assert "moksha_health_report:ok" in ctx.operations


### PR DESCRIPTION
Implementiert Schnitt A der finalisierten Spec (`specs/HEARTBEAT_FAILURE_PROPAGATION_FEATURE_01.md`, DRAFT 1.0, bedingtes GO aus #693).

## Impl-Schritt 1 zuerst: Versions-Gegenprüfung

Vor jeder Code-Zeile aus §5.3: `steward-protocol==0.3.2` installiert und die echten Formen von `CircuitBreaker.get_status()`, `OperationalQuota.get_status()`, `MahaCellUnified.is_alive` am Paket gelesen. Ergebnis: **keine Drift** — sie entsprechen exakt den in §5.3a gepinnten Formen.

## Was geändert wurde

`steward/hooks/moksha_health.py`:
- `_ShapeDrift`, `_breaker_ok`, `_quota_ok` — fail-laute Dekoder (Befund 1): werfen bei Form-Drift statt still „gesund" zu lesen.
- `execute()`: liest `prev`-Zustand nur (§5.2, keine Inkrementierung dort).
- `_build_health_report(prev)`: einzige Inkrement-Stelle (§5.3), erzeugt den `cognition`-Block mit `hard_down`, `degraded` (Zyklus-Delta), `skip_collapse`, `decode_error`, `consecutive_collapsed_cycles`.
- Bei Form-Drift: `decode_error` gesetzt, `logger.warning`, Streak eingefroren (nicht zurückgesetzt).

Kein Einfluss auf Run-Exit-Status, keine Kontrollfluss-Änderung außerhalb dieser Datei (§5.4-Invariante).

## Tests

`tests/test_moksha_health.py` — alle 11 Tests aus dem §6-Testvertrag: Builder-Ebene (healthy, hard-down, degraded, healthy-fallback-stays-green, transient-reset, no-provider, skip-collapse über echten Breaker-Pfad, `test_decode_error_fails_loud`) plus Disk-Roundtrip-Tests gegen die reale Health-JSON-Datei.

Verifiziert:
- Alle 11 neuen Tests grün.
- Keine Regression in `test_provider.py`/`test_phase_hooks.py`/`test_karma_hooks.py`.
- Manueller End-to-End-Lauf des echten Hooks erzeugt das Artefakt exakt wie in §7 spezifiziert (gesunder Zustand, `consecutive_collapsed_cycles: 0`).
- 8 vorbestehende Testfehler (fehlendes `pytest-asyncio`-Plugin, 1 unabhängiger Security-Test) reproduzieren identisch auf dem unveränderten Branch — nicht durch diese Änderung verursacht.

## Scope

Nur Schnitt A. B/C bleiben wie in der Spec gegated (§8) — kein Run-Rot, kein Feature-Flag aktiviert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1yezzee3cEALFCytxJ3zo)_