### PR TITLE
B1-A0A: Deny legacy mutations targeting Agent City

### DIFF
--- a/steward/actuators.py
+++ b/steward/actuators.py
@@ -20,6 +20,12 @@ import logging
 import subprocess
 from dataclasses import dataclass
 
+from steward.repository_policy import (
+    mutation_repository_allowed,
+    parse_repository,
+    repository_from_pr_url,
+)
+
 logger = logging.getLogger("STEWARD.ACTUATORS")
 
 _PROTECTED = frozenset({"main", "master", "develop", "release"})
@@ -298,10 +304,15 @@ class GitHubActuator:
             return None
         return result
 
-    def merge_pr(self, pr_number: int, method: str = "squash") -> ActuatorResult:
-        """Merge a PR. Method: merge, squash, rebase."""
+    def merge_pr(self, pr_number: int, method: str = "squash", *, repository: str | None = None) -> ActuatorResult:
+        """Merge only an explicitly allowlisted repository PR."""
+        repo = parse_repository(repository or "")
+        if repo is None or not mutation_repository_allowed(repo):
+            return ActuatorResult(success=False, error="BLOCKED: repository mutation boundary")
+        if method not in {"merge", "squash", "rebase"}:
+            return ActuatorResult(success=False, error="BLOCKED: invalid merge method")
         result = self._gh.call(
-            ["pr", "merge", str(pr_number), f"--{method}", "--delete-branch"],
+            ["pr", "merge", str(pr_number), "--repo", repo, f"--{method}", "--delete-branch"],
             timeout=30,
         )
         if result is None:
@@ -315,6 +326,9 @@ class GitHubActuator:
         all required status checks pass. Requires branch protection
         rules to be configured on the repo.
         """
+        parsed = repository_from_pr_url(pr_url)
+        if parsed is None or not mutation_repository_allowed(parsed[0]):
+            return ActuatorResult(success=False, error="BLOCKED: repository mutation boundary")
         result = self._gh.call(
             ["pr", "merge", "--auto", "--merge", pr_url.strip()],
             timeout=15,

--- a/steward/fix_pipeline.py
+++ b/steward/fix_pipeline.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Awaitable, Callable
 
 from steward import agent_memory
+from steward.repository_policy import mutation_repository_allowed, repository_from_pr_url
 from steward.services import SVC_MARKETPLACE
 from steward.tools.circuit_breaker import CircuitBreaker
 from vibe_core.di import ServiceRegistry
@@ -488,7 +489,14 @@ class FixPipeline:
                 )
                 if pr_url:
                     # Close the Kirtan: auto-merge when CI passes
-                    gh.call(["pr", "merge", "--auto", "--merge", pr_url.strip()], timeout=15)
+                    parsed = repository_from_pr_url(pr_url)
+                    if parsed is not None and mutation_repository_allowed(parsed[0]):
+                        gh.call(
+                            ["pr", "merge", "--auto", "--merge", pr_url.strip()],
+                            timeout=15,
+                        )
+                    else:
+                        logger.warning("Fix pipeline: auto-merge denied for ambiguous or protected repository")
                 return pr_url
 
         except Exception as e:

--- a/steward/pr_verdict_poster.py
+++ b/steward/pr_verdict_poster.py
@@ -19,6 +19,8 @@ import logging
 import os
 from pathlib import Path
 
+from steward.repository_policy import AGENT_CITY_REPOSITORY, parse_repository
+
 logger = logging.getLogger("STEWARD.PR_VERDICT")
 
 GITHUB_API = "https://api.github.com"
@@ -91,6 +93,17 @@ class PRVerdictPoster:
         Returns:
             True if review was posted successfully
         """
+        normalized_repo = parse_repository(repo)
+        if normalized_repo is None:
+            logger.warning("PR_VERDICT: ambiguous repository, refusing review post")
+            return False
+        if normalized_repo == AGENT_CITY_REPOSITORY:
+            logger.warning("PR_VERDICT: legacy review post denied for %s", normalized_repo)
+            return False
+        if not isinstance(pr_number, int) or isinstance(pr_number, bool) or pr_number <= 0:
+            logger.warning("PR_VERDICT: malformed pull request number")
+            return False
+        repo = normalized_repo
         if not self._token:
             logger.warning("PR_VERDICT: no GitHub token, skipping post")
             return False

--- a/steward/repository_policy.py
+++ b/steward/repository_policy.py
@@ -1,0 +1,50 @@
+"""Explicit repository boundaries for legacy GitHub mutation paths."""
+
+from __future__ import annotations
+
+import os
+import re
+from urllib.parse import urlparse
+
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+AGENT_CITY_REPOSITORY = "kimeisele/agent-city"
+STEWARD_REPOSITORY = "kimeisele/steward"
+
+
+def parse_repository(value: str) -> str | None:
+    """Parse an explicit owner/name or canonical GitHub PR URL."""
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if REPOSITORY_RE.fullmatch(value):
+        return value
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or parsed.netloc != "github.com" or parsed.query or parsed.fragment:
+        return None
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) != 4 or parts[2] != "pull" or not parts[3].isdigit():
+        return None
+    repo = f"{parts[0]}/{parts[1]}"
+    return repo if REPOSITORY_RE.fullmatch(repo) else None
+
+
+def repository_from_pr_url(value: str) -> tuple[str, int] | None:
+    repo = parse_repository(value)
+    if repo is None or "/pull/" not in value:
+        return None
+    parsed = urlparse(value.strip())
+    number = parsed.path.strip("/").split("/")[-1]
+    return repo, int(number)
+
+
+def allowed_mutation_repositories() -> frozenset[str]:
+    """Resolve the explicit legacy allowlist; default is Steward itself only."""
+    raw = os.environ.get("STEWARD_ALLOWED_MUTATION_REPOSITORIES", "")
+    if not raw.strip():
+        return frozenset({STEWARD_REPOSITORY})
+    values = {item.strip() for item in raw.split(",") if item.strip()}
+    return frozenset(value for value in values if REPOSITORY_RE.fullmatch(value))
+
+
+def mutation_repository_allowed(repository: str) -> bool:
+    return repository in allowed_mutation_repositories() and repository != AGENT_CITY_REPOSITORY

--- a/tests/test_actuators.py
+++ b/tests/test_actuators.py
@@ -279,7 +279,7 @@ class TestGitHubActuatorMergePR:
         gh.call.return_value = "Merged PR #1"
         actuator = GitHubActuator(gh_client=gh)
 
-        result = actuator.merge_pr(1)
+        result = actuator.merge_pr(1, repository="kimeisele/steward")
         assert result.success
 
     def test_merge_pr_rebase(self):
@@ -287,7 +287,7 @@ class TestGitHubActuatorMergePR:
         gh.call.return_value = "Merged"
         actuator = GitHubActuator(gh_client=gh)
 
-        actuator.merge_pr(1, method="rebase")
+        actuator.merge_pr(1, method="rebase", repository="kimeisele/steward")
         args = gh.call.call_args[0][0]
         assert "--rebase" in args
 
@@ -298,7 +298,7 @@ class TestGitHubActuatorEnableAutoMerge:
         gh.call.return_value = "Auto-merge enabled"
         actuator = GitHubActuator(gh_client=gh)
 
-        result = actuator.enable_auto_merge("https://github.com/owner/repo/pull/42")
+        result = actuator.enable_auto_merge("https://github.com/kimeisele/steward/pull/42")
         assert result.success
         args = gh.call.call_args[0][0]
         assert "--auto" in args
@@ -309,15 +309,45 @@ class TestGitHubActuatorEnableAutoMerge:
         gh.call.return_value = "Auto-merge enabled"
         actuator = GitHubActuator(gh_client=gh)
 
-        actuator.enable_auto_merge("  https://github.com/owner/repo/pull/42  \n")
+        actuator.enable_auto_merge("  https://github.com/kimeisele/steward/pull/42  \n")
         args = gh.call.call_args[0][0]
-        assert args[-1] == "https://github.com/owner/repo/pull/42"
+        assert args[-1] == "https://github.com/kimeisele/steward/pull/42"
 
     def test_enable_auto_merge_fails(self):
         gh = MagicMock()
         gh.call.return_value = None
         actuator = GitHubActuator(gh_client=gh)
 
-        result = actuator.enable_auto_merge("https://github.com/owner/repo/pull/42")
+        result = actuator.enable_auto_merge("https://github.com/kimeisele/steward/pull/42")
         assert not result.success
         assert "auto" in result.error.lower()
+
+
+def test_merge_pr_denies_agent_city_without_calling_github():
+    gh = MagicMock()
+    actuator = GitHubActuator(gh_client=gh)
+
+    result = actuator.merge_pr(42, repository="kimeisele/agent-city")
+
+    assert not result.success
+    gh.call.assert_not_called()
+
+
+def test_auto_merge_denies_agent_city_url_without_calling_github():
+    gh = MagicMock()
+    actuator = GitHubActuator(gh_client=gh)
+
+    result = actuator.enable_auto_merge("https://github.com/kimeisele/agent-city/pull/42")
+
+    assert not result.success
+    gh.call.assert_not_called()
+
+
+def test_auto_merge_rejects_malformed_url_without_calling_github():
+    gh = MagicMock()
+    actuator = GitHubActuator(gh_client=gh)
+
+    result = actuator.enable_auto_merge("https://evil.example/kimeisele/agent-city/pull/42")
+
+    assert not result.success
+    gh.call.assert_not_called()

--- a/tests/test_pr_verdict_poster.py
+++ b/tests/test_pr_verdict_poster.py
@@ -47,16 +47,11 @@ def test_post_verdict_no_token():
     assert result is False
 
 
-def test_post_verdict_creates_review():
+def test_agent_city_legacy_approve_is_denied_without_network_call():
     poster = PRVerdictPoster()
     poster._token = "ghp_test"
 
-    mock_response = MagicMock()
-    mock_response.status = 201
-    mock_response.__enter__ = MagicMock(return_value=mock_response)
-    mock_response.__exit__ = MagicMock(return_value=False)
-
-    with patch("urllib.request.urlopen", return_value=mock_response) as mock_open:
+    with patch("urllib.request.urlopen") as mock_open:
         result = poster.post_verdict(
             repo="kimeisele/agent-city",
             pr_number=42,
@@ -66,17 +61,25 @@ def test_post_verdict_creates_review():
             source_agent="steward",
         )
 
-    assert result is True
-    assert poster._post_count == 1
+    assert result is False
+    mock_open.assert_not_called()
+    assert poster._post_count == 0
 
-    # Verify the request was made correctly
-    call_args = mock_open.call_args
-    req = call_args[0][0]
-    assert "kimeisele/agent-city/pulls/42/reviews" in req.full_url
-    body = json.loads(req.data)
-    assert body["event"] == "APPROVE"
-    assert "steward" in body["body"]
-    assert "All checks passed" in body["body"]
+
+def test_own_steward_review_can_still_post():
+    poster = PRVerdictPoster()
+    poster._token = "ghp_test"
+    mock_response = MagicMock(status=201)
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_response) as mock_open:
+        result = poster.post_verdict(repo="kimeisele/steward", pr_number=42, verdict="comment")
+
+    assert result is True
+    req = mock_open.call_args[0][0]
+    assert "kimeisele/steward/pulls/42/reviews" in req.full_url
+    assert json.loads(req.data)["event"] == "COMMENT"
 
 
 def test_post_verdict_request_changes():
@@ -137,7 +140,7 @@ def test_post_from_nadi_event_full_payload():
     mock_response.__exit__ = MagicMock(return_value=False)
 
     payload = {
-        "repo": "kimeisele/agent-city",
+        "repo": "kimeisele/steward",
         "pr_number": 42,
         "verdict": "approve",
         "reason": "all checks passed",
@@ -149,6 +152,16 @@ def test_post_from_nadi_event_full_payload():
         result = poster.post_from_nadi_event(payload)
 
     assert result is True
+
+
+def test_post_from_nadi_event_rejects_malformed_repository():
+    poster = PRVerdictPoster()
+    poster._token = "ghp_test"
+
+    assert (
+        poster.post_from_nadi_event({"repo": "https://evil.example/kimeisele/steward/pull/42", "pr_number": 42})
+        is False
+    )
 
 
 # ── Stats ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Scope

Containment-only repository-boundary hardening for legacy Steward review and merge mutation paths.

## Baseline

- Base SHA: `98e35e061d6c324bf027daab27ab0ffef54bd83a`
- Commit: `7857b0726a`
- Production B1 runtime wiring: none
- B1 merge authority: not enabled

## Behavior

- Legacy PR review posting is denied for `kimeisele/agent-city`.
- Merge and auto-merge require an explicit parsed repository and explicit allowlist; Agent City is always denied.
- Fix-pipeline auto-merge uses the same boundary.
- Malformed and ambiguous URLs fail closed.
- Steward-owned repository behavior remains covered.

## Validation

- `pytest -q tests/test_actuators.py tests/test_pr_verdict_poster.py`: 51 passed
- Ruff: passed
- compileall: passed
- `git diff --check`: passed

No workflows, branch protection, credentials, B1 runtime wiring, or live GitHub mutation changed.