### PR TITLE
test: guard phonetic locality channel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "steward-protocol[providers]",
+    "steward-protocol[providers]>=0.3.3,<0.4",
     "rich>=13.0",
     "libcst>=1.0",
     "cryptography>=42.0",

--- a/tests/test_locality_channel.py
+++ b/tests/test_locality_channel.py
@@ -1,0 +1,30 @@
+"""Regression tests for the phonetic locality channel."""
+
+from vibe_core.mahamantra.adapters.compression import MahaCompression
+
+from steward.antahkarana.manas import Manas
+
+
+VARIANTS = [
+    "fix the failing test in test_agent.py",
+    "fix the failing test in test_agent.py.",
+    "Fix the failing test in test_agent.py",
+    "fix the failing test in test_agent.py ",
+]
+
+
+def test_category_invariant_under_punctuation_and_case():
+    """Punctuation and case variants keep the produced and consumed category."""
+    results = [MahaCompression().compress(value) for value in VARIANTS]
+    categories = {result.seed >> 24 for result in results}
+    positions = {result.position for result in results}
+
+    assert len(categories) == 1, f"Lokalitätskanal gebrochen: {categories}"
+    assert len(positions) == 1, f"Kategoriefeld wird falsch gelesen: {positions}"
+
+
+def test_tool_namespaces_invariant():
+    """Manas classification must not become a punctuation/case lottery."""
+    actions = {Manas().perceive(value).action for value in VARIANTS}
+
+    assert len(actions) == 1, f"Tool-Lotterie aktiv: {actions}"

--- a/tests/test_locality_channel.py
+++ b/tests/test_locality_channel.py
@@ -1,9 +1,7 @@
 """Regression tests for the phonetic locality channel."""
 
-from vibe_core.mahamantra.adapters.compression import MahaCompression
-
 from steward.antahkarana.manas import Manas
-
+from vibe_core.mahamantra.adapters.compression import MahaCompression
 
 VARIANTS = [
     "fix the failing test in test_agent.py",


### PR DESCRIPTION
## Was

Regression guards for the phonetic locality channel and a bounded
`steward-protocol` dependency.

## Änderung

- `tests/test_locality_channel.py`: category/position and Manas action remain
  invariant under punctuation, case, and trailing-space variants.
- `pyproject.toml`: `steward-protocol[providers]>=0.3.3,<0.4`.

The Steward workflow is intentionally unchanged.

## Commits

- `3d0c7ceed1 test: add locality channel guard tests`
- `3b60095d55 build: pin steward-protocol to >=0.3.3,<0.4`

Local validation: `2 passed` for `tests/test_locality_channel.py`.
