### PR TITLE
feat: surface buddhi tool suggestions as transient advisory hint

### DIFF
--- a/steward/loop/engine.py
+++ b/steward/loop/engine.py
@@ -183,6 +183,7 @@ class AgentLoop:
         self._feedback = feedback
         self._maha_llm = maha_llm
         self._siksastakam = siksastakam
+        self._tool_hint: str | None = None
 
         # Ensure system prompt is first message
         if system_prompt and (not conversation.messages or conversation.messages[0].role != MessageRole.SYSTEM):
@@ -334,6 +335,16 @@ class AgentLoop:
                 user_message, round_num, context_pct, seed=cr.seed, l0_guardian=l0_guardian
             )
             if round_num == 0:
+                suggested_tools = sorted(directive.tool_names)
+                registered_tools = self._registry.list_tools()
+                if 0 < len(suggested_tools) <= 8 and len(suggested_tools) < len(registered_tools):
+                    self._tool_hint = (
+                        "[Buddhi] For this task, these tools may be useful: "
+                        f"{', '.join(suggested_tools)}. "
+                        "All other tools remain fully available."
+                    )
+                else:
+                    self._tool_hint = None
                 usage.buddhi_action = directive.action.value
                 usage.buddhi_guna = directive.guna.value
                 usage.buddhi_tier = directive.tier.value
@@ -775,6 +786,14 @@ class AgentLoop:
             "messages": self._conversation.to_dicts(),
             "max_tokens": max_tokens,
         }
+
+        tool_hint = self._tool_hint
+        self._tool_hint = None
+        messages = kwargs["messages"]
+        if tool_hint and messages and messages[0].get("role") == MessageRole.SYSTEM:
+            system_message = dict(messages[0])
+            system_message["content"] = f"{system_message['content']}\n\n{tool_hint}"
+            messages[0] = system_message
 
         # Brain-in-a-jar: JSON mode (no tools parameter, saves ~1500 tokens/call)
         if self._json_mode:

--- a/tests/test_advisory_tools.py
+++ b/tests/test_advisory_tools.py
@@ -1,0 +1,71 @@
+"""Tests for fail-open Buddhi tool suggestions."""
+
+from dataclasses import replace
+from unittest.mock import patch
+
+from steward.agent import StewardAgent
+from tests.fakes import FakeLLM, FakeResponse
+
+
+def _narrow_directive(agent: StewardAgent):
+    directive = agent._buddhi.pre_flight("inspect the failing test", round_num=0)
+    tool_name = sorted(directive.tool_names)[0]
+    return replace(directive, tool_names=frozenset({tool_name}))
+
+
+def test_hint_is_present_for_narrow_classification():
+    """A narrow classification appears as an advisory round-context hint."""
+    llm = FakeLLM([FakeResponse(content='{"response": "done"}')])
+    agent = StewardAgent(provider=llm)
+    directive = _narrow_directive(agent)
+
+    with patch.object(agent._buddhi, "pre_flight", return_value=directive):
+        agent.run_sync("inspect the failing test")
+
+    messages = agent._provider.last_call["messages"]
+    context = "\n".join(str(message["content"]) for message in messages)
+    assert "[Buddhi] For this task, these tools may be useful:" in context
+    assert f"{next(iter(directive.tool_names))}." in context
+    assert "All other tools remain fully available." in context
+
+
+def test_no_tool_is_ever_removed():
+    """Fail-open behavior keeps every registered tool visible to the model.
+
+    This guard must fail if an advisory suggestion is later turned into a
+    restrictive filter, even when classification is forced to one tool.
+    """
+    llm = FakeLLM(
+        [
+            FakeResponse(content='{"response": "done"}'),
+            FakeResponse(content='{"response": "done"}'),
+        ]
+    )
+    agent = StewardAgent(provider=llm)
+    all_tool_names = {description["name"] for description in agent._registry.get_tool_descriptions()}
+    directive = _narrow_directive(agent)
+
+    with patch.object(agent._buddhi, "pre_flight", return_value=directive):
+        for user_message in ("inspect the failing test", "implement the fix"):
+            agent.run_sync(user_message)
+
+    for call in llm.calls:
+        system_prompt = str(call["messages"][0]["content"])
+        for tool_name in all_tool_names:
+            assert tool_name in system_prompt
+
+
+def test_hint_does_not_enter_conversation():
+    """The transient hint reaches the model but not the conversation log."""
+    llm = FakeLLM([FakeResponse(content='{"response": "done"}')])
+    agent = StewardAgent(provider=llm)
+    directive = _narrow_directive(agent)
+
+    with patch.object(agent._buddhi, "pre_flight", return_value=directive):
+        agent.run_sync("inspect the failing test")
+
+    stored_messages = agent.conversation.messages
+    assert len(stored_messages) == 3
+    assert all("[Buddhi]" not in message.content for message in stored_messages)
+    sent_system_prompt = llm.last_call["messages"][0]["content"]
+    assert "[Buddhi] For this task, these tools may be useful:" in sent_system_prompt


### PR DESCRIPTION
## Was

BuddhiDirective.tool_names wird als Hinweis im Rundenkontext sichtbar
gemacht — nicht als Filter.

Bisher wurde tool_names in buddhi.py:431 berechnet und nirgends konsumiert.
Mit steward-protocol 0.3.3 ist die zugrundeliegende Klassifikation erstmals
stabil (vorher lieferte dieselbe Eingabe mit abweichender Interpunktion eine
andere Kategorie), das Signal trägt also Information.

## Warum beratend

Sperrend würde jede Fehlklassifikation eine Fähigkeit entziehen. Die
Kontextersparnis durch Filtern wäre gering — lean_tool_signatures() erzeugt
~100 Token für ALLE Tools. Das Verhältnis rechtfertigt kein Risiko.

Der System-Prompt bleibt vollständig und alle Tools bleiben verfügbar. Der
Hinweis ist rein additiv.

## Transient, nicht persistent

Der Hinweis wird in _build_llm_kwargs() an die ausgehende Kopie der
System-Nachricht angehängt und berührt self._conversation nicht.

Grund: Als gespeicherte USER-Nachricht wäre eine interne Heuristik vom
tatsächlichen Nutzertext nicht mehr unterscheidbar, und der Hinweis stünde
in jeder Folgerunde erneut im Kontext — der Spareffekt der Beschränkung auf
Runde 0 wäre aufgehoben.

test_hint_does_not_enter_conversation wacht darüber.

## Fail-Open ist getestet

test_no_tool_is_ever_removed schlägt fehl, sobald aus dem Hinweis ein Filter
wird. Der Test existiert genau zu diesem Zweck.

## Testlage

Baseline: 2463 passed, 4 skipped
Nachher: 2466 passed, 4 skipped
Delta der bestehenden Tests: 0
Neue Tests: 3

Ruff: sauber, 229 Dateien bereits formatiert.

## Tokenwirkung

Runde 0: +33 Token
Runde 1/2: 0 zusätzliche Token
Mehr-Runden-Turn: usage.total_tokens 711 → 744 (+33)
cbr_budget unverändert: 7536

## Nicht Gegenstand

- North Star alignment bleibt abgeklemmt.
- CBR-Konstanten bleiben unverändert.
- check_tool_gates() und lean_tool_signatures() bleiben unverändert.